### PR TITLE
Implement UI vocabulary toggle (Basic/Advanced mode)

### DIFF
--- a/docs/chobo-future-ui-vocab.md
+++ b/docs/chobo-future-ui-vocab.md
@@ -1,34 +1,100 @@
 ---
-title: "CHOBO 将来論点 - 用語と UI 語彙"
+title: "CHOBO UI 用語 decision"
 date: "2026-03-20"
-updated: "2026-03-20"
-status: "draft"
+updated: "2026-03-21"
+status: "decided"
 source: "docs/chobo-future-topics.md"
+parent-issue: "#7"
+child-issues: ["#31", "#32"]
 ---
 
-# 用語と UI 語彙
+# UI 用語 decision
 
-## 1. 目的
+## 1. 概要
 
-UI の語彙を、生活用語ベースで固定し続けるか、上級者向け表示を許すかを整理する。
+CHOBO はユーザー設定による Basic/Advanced モード切り替えを採用する。
+Basic モードでは生活用語を、Advanced モードでは会計用語を使用する。
 
-## 2. 論点
+## 2. 生活用語マッピング (Basic モード)
 
-### 2.1 生活用語マッピング
+### 取引種別
 
-- 収入
-- 支出
-- 移動
-- カード払い
+| Internal | Basic | Advanced |
+|----------|-------|----------|
+| income | お金が入った | 収入 |
+| expense | お金を使った | 支出 |
+| transfer | お金の移動 | 振替 |
+| credit_expense | カードで支払い | カード支出 |
+| liability_payment | カードの支払い | 負債返済 |
 
-### 2.2 会計用語の露出制御
+### 方向
 
-- 借方・貸方を UI に出すか
-- 勘定種別をどこまで見せるか
-- ヘルプ文言の語彙をどう揃えるか
+| Internal | Basic | Advanced |
+|----------|-------|----------|
+| increase | 入 | 増加 |
+| decrease | 出 | 減少 |
 
-## 3. issue 分割の目安
+### 明細
 
-- `UI vocabulary map`
-- `Advanced accounting labels`
+| Index | Basic | Advanced |
+|-------|-------|----------|
+| 0 | 出金 | 明細 1 / 借方 |
+| 1 | 入金 | 明細 2 / 貸方 |
 
+## 3. 標準勘定科目名
+
+標準勘定科目の表示名も Basic/Advanced モードに従う。
+
+| English | Basic | Advanced |
+|---------|-------|----------|
+| Cash | 現金 | Cash |
+| Main Bank | メインバンク | Main Bank |
+| Salary | 給与 | Salary |
+| Food | 食費 | Food |
+| ... | ... | ... |
+
+## 4. 会計用語露出ポリシー
+
+### Advanced モードでのみ表示
+
+| 用語 | 説明 |
+|------|------|
+| 借方 | 左側。資産や負債の増加を記録 |
+| 貸方 | 右側。資産や負債の減少を記録 |
+| 勘定 | 取引を記録する科目 |
+| 仕訳 | 取引を借方・貸方に分解して記録 |
+
+### Basic モードでのツールチップ
+
+Basic モードでは、ラベルの上にホバー/タップで会計用語のツールチップを表示する。
+
+| Basic 用語 | ツールチップ |
+|------------|-------------|
+| 出金 | 出金（しゅっきん）：借方。資産や負債の増加を記録します |
+| 入金 | 入金（にゅうきん）：貸方。資産や負債の減少を記録します |
+| 借方 | 借方（かりかた）：左側。資産の増加または負債の減少を記録します |
+| 貸方 | 貸方（かしかた）：右側。資産の減少または負債の増加を記録します |
+
+## 5. 設定
+
+- **設定名:** Show Accounting Terminology / 会計用語を表示
+- **デフォルト:** オフ (Basic モード)
+- **適用範囲:** 入力フォーム、レポート、サマリー全て
+- **保存場所:** アプリ設定データベース
+
+## 6. 実装状況
+
+- [x] `ChoboAppSettings` に `terminologyMode` 追加
+- [x] `TerminologyService` プロバイダー実装
+- [x] `TermLabel` ウィジェット実装
+- [x] 取引編集画面のラベル更新
+- [x] 取引詳細画面のラベル更新
+- [x] ホーム画面のラベル更新
+- [x] 設定画面にトグル UI 追加
+
+## 7. 関連ファイル
+
+- `lib/core/terminology_labels.dart` - 用語定義
+- `lib/core/terminology_service.dart` - 用語サービス
+- `lib/widgets/term_label.dart` - 用語ラベルウィジェット
+- `lib/features/settings/settings_screen.dart` - 設定画面

--- a/lib/app/chobo_providers.dart
+++ b/lib/app/chobo_providers.dart
@@ -25,6 +25,8 @@ import '../data/service/monthly_summary_service.dart';
 import '../core/auth_service.dart';
 import '../core/audit_event_factory.dart';
 
+export '../core/terminology_service.dart';
+
 final appDatabaseProvider = Provider<AppDatabase>((ref) {
   return ref.watch(databaseManagerProvider);
 });

--- a/lib/core/terminology_labels.dart
+++ b/lib/core/terminology_labels.dart
@@ -1,0 +1,341 @@
+enum TransactionTerm {
+  income,
+  expense,
+  transfer,
+  creditExpense,
+  liabilityPayment,
+}
+
+enum DirectionTerm {
+  increase,
+  decrease,
+}
+
+enum EntryTerm {
+  first,
+  second,
+}
+
+enum StatusTerm {
+  posted,
+  pending,
+  voided,
+  periodOpen,
+  periodClosed,
+}
+
+enum SectionTerm {
+  basicInfo,
+  entries,
+  overview,
+  operations,
+}
+
+enum ActionTerm {
+  save,
+  edit,
+  back,
+  duplicate,
+  correction,
+  cancel,
+  voidAction,
+}
+
+enum FieldTerm {
+  transactionDate,
+  transactionType,
+  description,
+  counterparty,
+  externalRef,
+  amount,
+  memo,
+  account,
+  direction,
+}
+
+enum AccountKindTerm {
+  asset,
+  liability,
+  income,
+  expense,
+}
+
+class TerminologyLabels {
+  TerminologyLabels._();
+
+  static const Map<TransactionTerm, Map<String, String>> transactions = {
+    TransactionTerm.income: {
+      'basic': 'お金が入った',
+      'advanced': '収入',
+    },
+    TransactionTerm.expense: {
+      'basic': 'お金を使った',
+      'advanced': '支出',
+    },
+    TransactionTerm.transfer: {
+      'basic': 'お金の移動',
+      'advanced': '振替',
+    },
+    TransactionTerm.creditExpense: {
+      'basic': 'カードで支払い',
+      'advanced': 'カード支出',
+    },
+    TransactionTerm.liabilityPayment: {
+      'basic': 'カードの支払い',
+      'advanced': '負債返済',
+    },
+  };
+
+  static const Map<DirectionTerm, Map<String, String>> directions = {
+    DirectionTerm.increase: {
+      'basic': '入',
+      'advanced': '増加',
+    },
+    DirectionTerm.decrease: {
+      'basic': '出',
+      'advanced': '減少',
+    },
+  };
+
+  static const Map<EntryTerm, Map<String, String>> entries = {
+    EntryTerm.first: {
+      'basic': '出金',
+      'advanced': '明細 1 / 借方',
+    },
+    EntryTerm.second: {
+      'basic': '入金',
+      'advanced': '明細 2 / 貸方',
+    },
+  };
+
+  static const Map<StatusTerm, Map<String, String>> statuses = {
+    StatusTerm.posted: {
+      'basic': '計上済み',
+      'advanced': '計上済み',
+    },
+    StatusTerm.pending: {
+      'basic': '保留',
+      'advanced': '保留',
+    },
+    StatusTerm.voided: {
+      'basic': '取消済み',
+      'advanced': '取消済み',
+    },
+    StatusTerm.periodOpen: {
+      'basic': '未締め',
+      'advanced': '未締め',
+    },
+    StatusTerm.periodClosed: {
+      'basic': '締め済み',
+      'advanced': '締め済み',
+    },
+  };
+
+  static const Map<SectionTerm, Map<String, String>> sections = {
+    SectionTerm.basicInfo: {
+      'basic': '基本情報',
+      'advanced': '基本情報',
+    },
+    SectionTerm.entries: {
+      'basic': '明細',
+      'advanced': '明細',
+    },
+    SectionTerm.overview: {
+      'basic': '概要',
+      'advanced': '概要',
+    },
+    SectionTerm.operations: {
+      'basic': '操作',
+      'advanced': '操作',
+    },
+  };
+
+  static const Map<ActionTerm, Map<String, String>> actions = {
+    ActionTerm.save: {
+      'basic': '保存',
+      'advanced': '保存',
+    },
+    ActionTerm.edit: {
+      'basic': '編集',
+      'advanced': '編集',
+    },
+    ActionTerm.back: {
+      'basic': '戻る',
+      'advanced': '戻る',
+    },
+    ActionTerm.duplicate: {
+      'basic': '複製',
+      'advanced': '複製',
+    },
+    ActionTerm.correction: {
+      'basic': '訂正',
+      'advanced': '訂正',
+    },
+    ActionTerm.cancel: {
+      'basic': '取消',
+      'advanced': '取消',
+    },
+    ActionTerm.voidAction: {
+      'basic': '取消',
+      'advanced': '取消',
+    },
+  };
+
+  static const Map<FieldTerm, Map<String, String>> fields = {
+    FieldTerm.transactionDate: {
+      'basic': '取引日',
+      'advanced': '取引日',
+    },
+    FieldTerm.transactionType: {
+      'basic': '取引種別',
+      'advanced': '取引種別',
+    },
+    FieldTerm.description: {
+      'basic': '説明',
+      'advanced': '説明',
+    },
+    FieldTerm.counterparty: {
+      'basic': '相手先',
+      'advanced': '相手先',
+    },
+    FieldTerm.externalRef: {
+      'basic': '外部参照',
+      'advanced': '外部参照',
+    },
+    FieldTerm.amount: {
+      'basic': '金額',
+      'advanced': '金額',
+    },
+    FieldTerm.memo: {
+      'basic': 'メモ',
+      'advanced': 'メモ',
+    },
+    FieldTerm.account: {
+      'basic': '口座',
+      'advanced': '勘定',
+    },
+    FieldTerm.direction: {
+      'basic': '方向',
+      'advanced': '方向',
+    },
+  };
+
+  static const Map<AccountKindTerm, Map<String, String>> accountKinds = {
+    AccountKindTerm.asset: {
+      'basic': '資産',
+      'advanced': '資産',
+    },
+    AccountKindTerm.liability: {
+      'basic': '負債',
+      'advanced': '負債',
+    },
+    AccountKindTerm.income: {
+      'basic': '収入',
+      'advanced': '収入',
+    },
+    AccountKindTerm.expense: {
+      'basic': '支出',
+      'advanced': '支出',
+    },
+  };
+
+  static const Map<String, String> tooltips = {
+    '出金': '出金（しゅっきん）：借方。資産や負債の増加を記録します',
+    '入金': '入金（にゅうきん）：貸方。資産や負債の減少を記録します',
+    '借方': '借方（かりかた）：左側。資産の増加または負債の減少を記録します',
+    '貸方': '貸方（かしかた）：右側。資産の減少または負債の増加を記録します',
+    '勘定': '勘定（かんじょう）：取引を記録する科目です',
+    '仕訳': '仕訳（しわけ）：取引を借方・貸方に分解して記録することです',
+  };
+
+  static const Map<String, Map<String, String>> standardAccountNames = {
+    'Cash': {
+      'basic': '現金',
+      'advanced': 'Cash',
+    },
+    'Main Bank': {
+      'basic': 'メインバンク',
+      'advanced': 'Main Bank',
+    },
+    'E Money': {
+      'basic': '電子マネー',
+      'advanced': 'E Money',
+    },
+    'Savings': {
+      'basic': '貯蓄',
+      'advanced': 'Savings',
+    },
+    'Main Card': {
+      'basic': 'メインカード',
+      'advanced': 'Main Card',
+    },
+    'Other Payable': {
+      'basic': 'その他支払',
+      'advanced': 'Other Payable',
+    },
+    'Salary': {
+      'basic': '給与',
+      'advanced': 'Salary',
+    },
+    'Side Job': {
+      'basic': '副業',
+      'advanced': 'Side Job',
+    },
+    'Refund': {
+      'basic': '返金',
+      'advanced': 'Refund',
+    },
+    'Point Reward': {
+      'basic': 'ポイント',
+      'advanced': 'Point Reward',
+    },
+    'Adjustment': {
+      'basic': '調整',
+      'advanced': 'Adjustment',
+    },
+    'Food': {
+      'basic': '食費',
+      'advanced': 'Food',
+    },
+    'Housing': {
+      'basic': '住居',
+      'advanced': 'Housing',
+    },
+    'Utilities': {
+      'basic': '光熱費',
+      'advanced': 'Utilities',
+    },
+    'Communication': {
+      'basic': '通信費',
+      'advanced': 'Communication',
+    },
+    'Transport': {
+      'basic': '交通費',
+      'advanced': 'Transport',
+    },
+    'Daily Goods': {
+      'basic': '日用品',
+      'advanced': 'Daily Goods',
+    },
+    'Medical': {
+      'basic': '医療',
+      'advanced': 'Medical',
+    },
+    'Education': {
+      'basic': '教育',
+      'advanced': 'Education',
+    },
+    'Entertainment': {
+      'basic': '娯楽',
+      'advanced': 'Entertainment',
+    },
+    'Social': {
+      'basic': '交的経費',
+      'advanced': 'Social',
+    },
+    'Special': {
+      'basic': '特別費',
+      'advanced': 'Special',
+    },
+  };
+}

--- a/lib/core/terminology_service.dart
+++ b/lib/core/terminology_service.dart
@@ -1,0 +1,168 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../data/local_db/chobo_records.dart';
+import '../data/repository/settings_repository.dart';
+import '../app/chobo_providers.dart';
+import 'terminology_labels.dart';
+
+final terminologyModeProvider =
+    StateNotifierProvider<TerminologyModeNotifier, String>((ref) {
+  final settingsRepo = ref.watch(settingsRepositoryProvider);
+  return TerminologyModeNotifier(settingsRepo);
+});
+
+class TerminologyModeNotifier extends StateNotifier<String> {
+  final SettingsRepository _settingsRepo;
+
+  TerminologyModeNotifier(this._settingsRepo)
+      : super(ChoboAppSettings.defaultTerminologyMode) {
+    _loadSetting();
+  }
+
+  Future<void> _loadSetting() async {
+    final setting = await _settingsRepo.getSetting(
+      ChoboAppSettings.terminologyMode,
+    );
+    if (setting != null) {
+      state = setting.settingValue;
+    }
+  }
+
+  Future<void> setMode(String mode) async {
+    await _settingsRepo.setSetting(
+      ChoboSettingRecord(
+        settingKey: ChoboAppSettings.terminologyMode,
+        settingValue: mode,
+      ),
+    );
+    state = mode;
+  }
+
+  bool get isAdvancedMode => state == ChoboAppSettings.terminologyModeAdvanced;
+}
+
+final terminologyServiceProvider = Provider<TerminologyService>((ref) {
+  final mode = ref.watch(terminologyModeProvider);
+  return TerminologyService(mode);
+});
+
+class TerminologyService {
+  final String _mode;
+
+  TerminologyService(this._mode);
+
+  String get mode => _mode;
+
+  bool get isAdvanced => _mode == ChoboAppSettings.terminologyModeAdvanced;
+
+  String _getLabel<T>(Map<T, Map<String, String>> map, T key) {
+    final modeKey = isAdvanced
+        ? ChoboAppSettings.terminologyModeAdvanced
+        : ChoboAppSettings.terminologyModeBasic;
+    return map[key]?[modeKey] ?? '';
+  }
+
+  String getTransactionLabel(TransactionTerm term) {
+    return _getLabel(TerminologyLabels.transactions, term);
+  }
+
+  String getDirectionLabel(DirectionTerm term) {
+    return _getLabel(TerminologyLabels.directions, term);
+  }
+
+  String getEntryLabel(EntryTerm term) {
+    return _getLabel(TerminologyLabels.entries, term);
+  }
+
+  String getStatusLabel(StatusTerm term) {
+    return _getLabel(TerminologyLabels.statuses, term);
+  }
+
+  String getSectionLabel(SectionTerm term) {
+    return _getLabel(TerminologyLabels.sections, term);
+  }
+
+  String getActionLabel(ActionTerm term) {
+    return _getLabel(TerminologyLabels.actions, term);
+  }
+
+  String getFieldLabel(FieldTerm term) {
+    return _getLabel(TerminologyLabels.fields, term);
+  }
+
+  String getAccountKindLabel(AccountKindTerm term) {
+    return _getLabel(TerminologyLabels.accountKinds, term);
+  }
+
+  String getStandardAccountName(String englishName) {
+    final names = TerminologyLabels.standardAccountNames[englishName];
+    if (names == null) return englishName;
+    final modeKey = isAdvanced
+        ? ChoboAppSettings.terminologyModeAdvanced
+        : ChoboAppSettings.terminologyModeBasic;
+    return names[modeKey] ?? englishName;
+  }
+
+  String? getTooltip(String key) {
+    if (isAdvanced) return null;
+    return TerminologyLabels.tooltips[key];
+  }
+
+  String getTransactionLabelForType(String type) {
+    switch (type) {
+      case 'income':
+        return getTransactionLabel(TransactionTerm.income);
+      case 'expense':
+        return getTransactionLabel(TransactionTerm.expense);
+      case 'transfer':
+        return getTransactionLabel(TransactionTerm.transfer);
+      case 'credit_expense':
+        return getTransactionLabel(TransactionTerm.creditExpense);
+      case 'liability_payment':
+        return getTransactionLabel(TransactionTerm.liabilityPayment);
+      default:
+        return type;
+    }
+  }
+
+  String getDirectionLabelForDirection(String direction) {
+    switch (direction) {
+      case 'increase':
+        return getDirectionLabel(DirectionTerm.increase);
+      case 'decrease':
+        return getDirectionLabel(DirectionTerm.decrease);
+      default:
+        return direction;
+    }
+  }
+
+  String getEntryLabelForIndex(int index) {
+    return getEntryLabel(
+      index == 0 ? EntryTerm.first : EntryTerm.second,
+    );
+  }
+
+  String getStatusLabelForStatus(String status) {
+    switch (status) {
+      case 'posted':
+        return getStatusLabel(StatusTerm.posted);
+      case 'pending':
+        return getStatusLabel(StatusTerm.pending);
+      case 'void':
+        return getStatusLabel(StatusTerm.voided);
+      default:
+        return status;
+    }
+  }
+
+  String getPeriodStateLabel(String state) {
+    switch (state) {
+      case 'open':
+        return getStatusLabel(StatusTerm.periodOpen);
+      case 'closed':
+        return getStatusLabel(StatusTerm.periodClosed);
+      default:
+        return state;
+    }
+  }
+}

--- a/lib/data/local_db/chobo_records.dart
+++ b/lib/data/local_db/chobo_records.dart
@@ -397,4 +397,11 @@ class ChoboAppSettings {
   static const String auditGranularityFull = 'full';
 
   static const int defaultCacheDurationSeconds = 300;
+
+  static const String terminologyMode = 'terminology_mode';
+
+  static const String terminologyModeBasic = 'basic';
+  static const String terminologyModeAdvanced = 'advanced';
+
+  static const String defaultTerminologyMode = terminologyModeBasic;
 }

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -39,6 +39,10 @@ class HomeScreen extends ConsumerWidget {
                 style: Theme.of(context).textTheme.headlineSmall,
               ),
               const SizedBox(height: 12),
+              Text(
+                '取引一覧',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
               ...transactions.map(
                 (transaction) => Padding(
                   padding: const EdgeInsets.only(bottom: 12),

--- a/lib/features/home/transaction_list_tile.dart
+++ b/lib/features/home/transaction_list_tile.dart
@@ -1,8 +1,11 @@
 import 'package:chobo/data/local_db/chobo_records.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-class TransactionListTile extends StatelessWidget {
+import '../../app/chobo_providers.dart';
+
+class TransactionListTile extends ConsumerWidget {
   const TransactionListTile({
     super.key,
     required this.transaction,
@@ -11,16 +14,20 @@ class TransactionListTile extends StatelessWidget {
   final ChoboTransactionRecord transaction;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final termService = ref.watch(terminologyServiceProvider);
+    final typeLabel = termService.getTransactionLabelForType(transaction.type);
+    final statusLabel = termService.getStatusLabelForStatus(transaction.status);
+
     return Card(
       child: ListTile(
         contentPadding: const EdgeInsets.all(16),
         title: Text(
-          transaction.description ?? transaction.type,
+          transaction.description ?? typeLabel,
           style: Theme.of(context).textTheme.titleMedium,
         ),
         subtitle: Text(
-          '${transaction.date} · ${transaction.status}',
+          '${transaction.date} · $statusLabel',
           style: Theme.of(context).textTheme.bodySmall,
         ),
         trailing: const Icon(Icons.chevron_right),

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -17,6 +17,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   bool _appLockEnabled = false;
   bool _biometricAvailable = false;
   int _cacheDurationSeconds = ChoboAppSettings.defaultCacheDurationSeconds;
+  bool _isAdvancedTerminology = false;
 
   @override
   void initState() {
@@ -32,6 +33,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         await settingsRepo.getSetting(ChoboAppSettings.appLockEnabled);
     final cacheSetting =
         await settingsRepo.getSetting(ChoboAppSettings.cacheDurationSeconds);
+    final terminologySetting =
+        await settingsRepo.getSetting(ChoboAppSettings.terminologyMode);
     final biometricAvailable = await authService.isBiometricAvailable();
 
     if (mounted) {
@@ -41,6 +44,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         _cacheDurationSeconds =
             int.tryParse(cacheSetting?.settingValue ?? '') ??
                 ChoboAppSettings.defaultCacheDurationSeconds;
+        _isAdvancedTerminology = terminologySetting?.settingValue ==
+            ChoboAppSettings.terminologyModeAdvanced;
         _isLoading = false;
       });
     }
@@ -87,6 +92,21 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     if (mounted) {
       setState(() {
         _cacheDurationSeconds = seconds;
+      });
+    }
+  }
+
+  Future<void> _toggleTerminologyMode(bool advanced) async {
+    final mode = advanced
+        ? ChoboAppSettings.terminologyModeAdvanced
+        : ChoboAppSettings.terminologyModeBasic;
+
+    final notifier = ref.read(terminologyModeProvider.notifier);
+    await notifier.setMode(mode);
+
+    if (mounted) {
+      setState(() {
+        _isAdvancedTerminology = advanced;
       });
     }
   }
@@ -159,6 +179,16 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             ),
           ),
           const SizedBox(height: 8),
+          const Divider(),
+          const _SectionHeader(title: 'Display'),
+          SwitchListTile(
+            title: const Text('Show Accounting Terminology'),
+            subtitle: const Text(
+              'Display terms like 借方/貸方 instead of 入/出',
+            ),
+            value: _isAdvancedTerminology,
+            onChanged: _toggleTerminologyMode,
+          ),
           const Divider(),
           const _SectionHeader(title: 'About'),
           const ListTile(

--- a/lib/features/transactions/transaction_detail_screen.dart
+++ b/lib/features/transactions/transaction_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../app/chobo_providers.dart';
+import '../../core/terminology_labels.dart';
 
 class TransactionDetailScreen extends ConsumerWidget {
   const TransactionDetailScreen({
@@ -57,47 +58,65 @@ class TransactionDetailScreen extends ConsumerWidget {
             children: <Widget>[
               Text(
                 transaction.description ??
-                    _transactionTypeLabel(transaction.type),
+                    ref
+                        .watch(terminologyServiceProvider)
+                        .getTransactionLabelForType(transaction.type),
                 style: Theme.of(context).textTheme.headlineSmall,
               ),
               const SizedBox(height: 8),
               Text(
-                '${transaction.date} · ${_statusLabel(transaction.status)}',
+                '${transaction.date} · ${ref.watch(terminologyServiceProvider).getStatusLabelForStatus(transaction.status)}',
                 style: Theme.of(context).textTheme.bodyMedium,
               ),
               const SizedBox(height: 16),
               _Section(
-                title: '概要',
+                title: ref
+                    .watch(terminologyServiceProvider)
+                    .getSectionLabel(SectionTerm.overview),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
-                    _DetailRow(label: '取引日', value: transaction.date),
+                    _DetailRow(
+                        label: ref
+                            .watch(terminologyServiceProvider)
+                            .getFieldLabel(FieldTerm.transactionDate),
+                        value: transaction.date),
                     const SizedBox(height: 12),
                     _DetailRow(
                       label: '種別',
-                      value: _transactionTypeLabel(transaction.type),
+                      value: ref
+                          .watch(terminologyServiceProvider)
+                          .getTransactionLabelForType(transaction.type),
                     ),
                     const SizedBox(height: 12),
                     _DetailRow(
                       label: '状態',
-                      value: _statusLabel(transaction.status),
+                      value: ref
+                          .watch(terminologyServiceProvider)
+                          .getStatusLabelForStatus(transaction.status),
                     ),
                     const SizedBox(height: 12),
                     _DetailRow(
                       label: '締め状態',
-                      value: _periodLockStateLabel(transaction.periodLockState),
+                      value: ref
+                          .watch(terminologyServiceProvider)
+                          .getPeriodStateLabel(transaction.periodLockState),
                     ),
                     if (transaction.counterparty != null) ...[
                       const SizedBox(height: 12),
                       _DetailRow(
-                        label: '相手先',
+                        label: ref
+                            .watch(terminologyServiceProvider)
+                            .getFieldLabel(FieldTerm.counterparty),
                         value: transaction.counterparty!,
                       ),
                     ],
                     if (transaction.externalRef != null) ...[
                       const SizedBox(height: 12),
                       _DetailRow(
-                        label: '外部参照',
+                        label: ref
+                            .watch(terminologyServiceProvider)
+                            .getFieldLabel(FieldTerm.externalRef),
                         value: transaction.externalRef!,
                       ),
                     ],
@@ -106,7 +125,9 @@ class TransactionDetailScreen extends ConsumerWidget {
               ),
               const SizedBox(height: 16),
               _Section(
-                title: '明細',
+                title: ref
+                    .watch(terminologyServiceProvider)
+                    .getSectionLabel(SectionTerm.entries),
                 child: entriesAsync.when(
                   data: (entries) {
                     if (entries.isEmpty) {
@@ -115,20 +136,23 @@ class TransactionDetailScreen extends ConsumerWidget {
 
                     return Column(
                       children: entries.asMap().entries.map((entry) {
-                        final index = entry.key + 1;
+                        final index = entry.key;
                         final value = entry.value;
-                        final accountName =
-                            accountNames[value.accountId] ?? value.accountId;
+                        final termService =
+                            ref.watch(terminologyServiceProvider);
+                        final accountName = termService.getStandardAccountName(
+                            accountNames[value.accountId] ?? value.accountId);
 
                         return Padding(
                           padding: EdgeInsets.only(
                             bottom: index == entries.length ? 0 : 12,
                           ),
                           child: _EntryCard(
-                            index: index,
+                            entryIndex: index,
                             accountName: accountName,
                             accountId: value.accountId,
-                            directionLabel: _directionLabel(value.direction),
+                            directionLabel: termService
+                                .getDirectionLabelForDirection(value.direction),
                             amountLabel: _signedAmountLabel(
                               value.direction,
                               value.amount,
@@ -151,7 +175,9 @@ class TransactionDetailScreen extends ConsumerWidget {
               ),
               const SizedBox(height: 16),
               _Section(
-                title: '操作',
+                title: ref
+                    .watch(terminologyServiceProvider)
+                    .getSectionLabel(SectionTerm.operations),
                 child: decisionAsync.when(
                   data: (decision) {
                     return Column(
@@ -325,8 +351,9 @@ class TransactionDetailScreen extends ConsumerWidget {
   }
 }
 
-class _ActionButtons extends StatelessWidget {
+class _ActionButtons extends ConsumerWidget {
   const _ActionButtons({
+    super.key,
     required this.voidLabel,
     required this.onDuplicate,
     required this.onCorrection,
@@ -339,18 +366,19 @@ class _ActionButtons extends StatelessWidget {
   final VoidCallback? onVoid;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final termService = ref.watch(terminologyServiceProvider);
     return Wrap(
       spacing: 12,
       runSpacing: 12,
       children: <Widget>[
         OutlinedButton(
           onPressed: onDuplicate,
-          child: const Text('複製'),
+          child: Text(termService.getActionLabel(ActionTerm.duplicate)),
         ),
         FilledButton.tonal(
           onPressed: onCorrection,
-          child: const Text('訂正'),
+          child: Text(termService.getActionLabel(ActionTerm.correction)),
         ),
         FilledButton(
           onPressed: onVoid,
@@ -388,9 +416,10 @@ class _Section extends StatelessWidget {
   }
 }
 
-class _EntryCard extends StatelessWidget {
+class _EntryCard extends ConsumerWidget {
   const _EntryCard({
-    required this.index,
+    super.key,
+    required this.entryIndex,
     required this.accountName,
     required this.accountId,
     required this.directionLabel,
@@ -399,7 +428,7 @@ class _EntryCard extends StatelessWidget {
     this.memo,
   });
 
-  final int index;
+  final int entryIndex;
   final String accountName;
   final String accountId;
   final String directionLabel;
@@ -408,8 +437,10 @@ class _EntryCard extends StatelessWidget {
   final String? memo;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
+    final termService = ref.watch(terminologyServiceProvider);
+    final displayLabel = termService.getEntryLabelForIndex(entryIndex);
 
     return Card(
       elevation: 0,
@@ -427,7 +458,7 @@ class _EntryCard extends StatelessWidget {
                   backgroundColor: theme.colorScheme.primaryContainer,
                   foregroundColor: theme.colorScheme.onPrimaryContainer,
                   child: Text(
-                    '$index',
+                    '${entryIndex + 1}',
                     style: theme.textTheme.labelSmall,
                   ),
                 ),
@@ -462,7 +493,7 @@ class _EntryCard extends StatelessWidget {
               spacing: 8,
               runSpacing: 8,
               children: <Widget>[
-                _Pill(label: directionLabel),
+                _Pill(label: displayLabel),
                 if (memo != null && memo!.isNotEmpty) _Pill(label: memo!),
               ],
             ),
@@ -528,58 +559,6 @@ class _DetailRow extends StatelessWidget {
         ),
       ],
     );
-  }
-}
-
-String _directionLabel(String direction) {
-  switch (direction) {
-    case 'increase':
-      return '増加';
-    case 'decrease':
-      return '減少';
-    default:
-      return direction;
-  }
-}
-
-String _statusLabel(String status) {
-  switch (status) {
-    case 'posted':
-      return '計上済み';
-    case 'pending':
-      return '保留';
-    case 'void':
-      return '取消済み';
-    default:
-      return status;
-  }
-}
-
-String _transactionTypeLabel(String type) {
-  switch (type) {
-    case 'income':
-      return '収入';
-    case 'expense':
-      return '支出';
-    case 'transfer':
-      return '振替';
-    case 'credit_expense':
-      return 'カード支出';
-    case 'liability_payment':
-      return '負債返済';
-    default:
-      return type;
-  }
-}
-
-String _periodLockStateLabel(String state) {
-  switch (state) {
-    case 'open':
-      return '未締め';
-    case 'closed':
-      return '締め済み';
-    default:
-      return state;
   }
 }
 

--- a/lib/features/transactions/transaction_edit_screen.dart
+++ b/lib/features/transactions/transaction_edit_screen.dart
@@ -4,6 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../app/chobo_providers.dart';
+import '../../core/terminology_labels.dart';
+import '../../core/terminology_service.dart';
 
 class TransactionEditScreen extends ConsumerStatefulWidget {
   const TransactionEditScreen({
@@ -39,6 +41,8 @@ class _TransactionEditScreenState extends ConsumerState<TransactionEditScreen> {
   bool _initialised = false;
   bool _saving = false;
   String _selectedType = 'expense';
+
+  TerminologyService get _termService => ref.read(terminologyServiceProvider);
 
   @override
   void dispose() {
@@ -87,7 +91,7 @@ class _TransactionEditScreenState extends ConsumerState<TransactionEditScreen> {
                   height: 18,
                   child: CircularProgressIndicator(strokeWidth: 2),
                 )
-              : const Text('保存'),
+              : Text(_termService.getActionLabel(ActionTerm.save)),
         ),
       ),
       body: transactionAsync.when(
@@ -145,13 +149,14 @@ class _TransactionEditScreenState extends ConsumerState<TransactionEditScreen> {
                   const SizedBox(height: 16),
                 ],
                 _Section(
-                  title: '基本情報',
+                  title: _termService.getSectionLabel(SectionTerm.basicInfo),
                   child: Column(
                     children: <Widget>[
                       TextFormField(
                         controller: _dateController,
-                        decoration: const InputDecoration(
-                          labelText: '取引日',
+                        decoration: InputDecoration(
+                          labelText: _termService
+                              .getFieldLabel(FieldTerm.transactionDate),
                           hintText: '2026-03-20',
                         ),
                         validator: (value) {
@@ -168,17 +173,11 @@ class _TransactionEditScreenState extends ConsumerState<TransactionEditScreen> {
                       const SizedBox(height: 16),
                       DropdownButtonFormField<String>(
                         value: _selectedType,
-                        decoration: const InputDecoration(
-                          labelText: '取引種別',
+                        decoration: InputDecoration(
+                          labelText: _termService
+                              .getFieldLabel(FieldTerm.transactionType),
                         ),
-                        items: _transactionTypeOptions
-                            .map(
-                              (option) => DropdownMenuItem<String>(
-                                value: option.value,
-                                child: Text(option.label),
-                              ),
-                            )
-                            .toList(growable: false),
+                        items: _buildTransactionTypeItems(),
                         onChanged: (value) {
                           if (value == null) {
                             return;
@@ -191,22 +190,25 @@ class _TransactionEditScreenState extends ConsumerState<TransactionEditScreen> {
                       const SizedBox(height: 16),
                       TextFormField(
                         controller: _descriptionController,
-                        decoration: const InputDecoration(
-                          labelText: '説明',
+                        decoration: InputDecoration(
+                          labelText:
+                              _termService.getFieldLabel(FieldTerm.description),
                         ),
                       ),
                       const SizedBox(height: 16),
                       TextFormField(
                         controller: _counterpartyController,
-                        decoration: const InputDecoration(
-                          labelText: '相手先',
+                        decoration: InputDecoration(
+                          labelText: _termService
+                              .getFieldLabel(FieldTerm.counterparty),
                         ),
                       ),
                       const SizedBox(height: 16),
                       TextFormField(
                         controller: _externalRefController,
-                        decoration: const InputDecoration(
-                          labelText: '外部参照',
+                        decoration: InputDecoration(
+                          labelText:
+                              _termService.getFieldLabel(FieldTerm.externalRef),
                         ),
                       ),
                     ],
@@ -214,12 +216,12 @@ class _TransactionEditScreenState extends ConsumerState<TransactionEditScreen> {
                 ),
                 const SizedBox(height: 16),
                 _Section(
-                  title: '明細',
+                  title: _termService.getSectionLabel(SectionTerm.entries),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
                       _EditableEntryCard(
-                        label: '明細 1',
+                        entryIndex: 0,
                         accounts: accounts,
                         accountId: _selectedAccountIds[0],
                         onAccountChanged: (value) {
@@ -241,7 +243,7 @@ class _TransactionEditScreenState extends ConsumerState<TransactionEditScreen> {
                       ),
                       const SizedBox(height: 12),
                       _EditableEntryCard(
-                        label: '明細 2',
+                        entryIndex: 1,
                         accounts: accounts,
                         accountId: _selectedAccountIds[1],
                         onAccountChanged: (value) {
@@ -392,6 +394,33 @@ class _TransactionEditScreenState extends ConsumerState<TransactionEditScreen> {
     final text = value.trim();
     return text.isEmpty ? null : text;
   }
+
+  List<DropdownMenuItem<String>> _buildTransactionTypeItems() {
+    return [
+      DropdownMenuItem<String>(
+        value: 'income',
+        child: Text(_termService.getTransactionLabel(TransactionTerm.income)),
+      ),
+      DropdownMenuItem<String>(
+        value: 'expense',
+        child: Text(_termService.getTransactionLabel(TransactionTerm.expense)),
+      ),
+      DropdownMenuItem<String>(
+        value: 'transfer',
+        child: Text(_termService.getTransactionLabel(TransactionTerm.transfer)),
+      ),
+      DropdownMenuItem<String>(
+        value: 'credit_expense',
+        child: Text(
+            _termService.getTransactionLabel(TransactionTerm.creditExpense)),
+      ),
+      DropdownMenuItem<String>(
+        value: 'liability_payment',
+        child: Text(
+            _termService.getTransactionLabel(TransactionTerm.liabilityPayment)),
+      ),
+    ];
+  }
 }
 
 class _Section extends StatelessWidget {
@@ -421,9 +450,10 @@ class _Section extends StatelessWidget {
   }
 }
 
-class _EditableEntryCard extends StatelessWidget {
+class _EditableEntryCard extends ConsumerWidget {
   const _EditableEntryCard({
-    required this.label,
+    super.key,
+    required this.entryIndex,
     required this.accounts,
     required this.accountId,
     required this.onAccountChanged,
@@ -433,7 +463,7 @@ class _EditableEntryCard extends StatelessWidget {
     required this.memoController,
   });
 
-  final String label;
+  final int entryIndex;
   final List<ChoboAccountRecord> accounts;
   final String? accountId;
   final ValueChanged<String?> onAccountChanged;
@@ -443,7 +473,8 @@ class _EditableEntryCard extends StatelessWidget {
   final TextEditingController memoController;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final termService = ref.watch(terminologyServiceProvider);
     return Card(
       elevation: 0,
       child: Padding(
@@ -451,21 +482,26 @@ class _EditableEntryCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            Text(label, style: Theme.of(context).textTheme.titleSmall),
+            Text(
+              termService.getEntryLabelForIndex(entryIndex),
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
             const SizedBox(height: 12),
             DropdownButtonFormField<String>(
               value: accountId,
-              decoration: const InputDecoration(
-                labelText: '口座',
+              decoration: InputDecoration(
+                labelText: termService.getFieldLabel(FieldTerm.account),
               ),
-              items: accounts
-                  .map(
-                    (account) => DropdownMenuItem<String>(
-                      value: account.accountId,
-                      child: Text('${account.name} (${account.accountId})'),
-                    ),
-                  )
-                  .toList(growable: false),
+              items: accounts.map(
+                (account) {
+                  final displayName =
+                      termService.getStandardAccountName(account.name);
+                  return DropdownMenuItem<String>(
+                    value: account.accountId,
+                    child: Text('$displayName (${account.accountId})'),
+                  );
+                },
+              ).toList(growable: false),
               onChanged: onAccountChanged,
               validator: (value) {
                 if (value == null || value.isEmpty) {
@@ -477,17 +513,19 @@ class _EditableEntryCard extends StatelessWidget {
             const SizedBox(height: 16),
             DropdownButtonFormField<String>(
               value: direction,
-              decoration: const InputDecoration(
-                labelText: '方向',
+              decoration: InputDecoration(
+                labelText: termService.getFieldLabel(FieldTerm.direction),
               ),
-              items: const <DropdownMenuItem<String>>[
+              items: [
                 DropdownMenuItem<String>(
                   value: 'decrease',
-                  child: Text('減少'),
+                  child: Text(
+                      termService.getDirectionLabel(DirectionTerm.decrease)),
                 ),
                 DropdownMenuItem<String>(
                   value: 'increase',
-                  child: Text('増加'),
+                  child: Text(
+                      termService.getDirectionLabel(DirectionTerm.increase)),
                 ),
               ],
               onChanged: onDirectionChanged,
@@ -502,8 +540,8 @@ class _EditableEntryCard extends StatelessWidget {
             TextFormField(
               controller: amountController,
               keyboardType: TextInputType.number,
-              decoration: const InputDecoration(
-                labelText: '金額',
+              decoration: InputDecoration(
+                labelText: termService.getFieldLabel(FieldTerm.amount),
               ),
               validator: (value) {
                 final amount = int.tryParse(value?.trim() ?? '');
@@ -516,8 +554,8 @@ class _EditableEntryCard extends StatelessWidget {
             const SizedBox(height: 16),
             TextFormField(
               controller: memoController,
-              decoration: const InputDecoration(
-                labelText: 'メモ',
+              decoration: InputDecoration(
+                labelText: termService.getFieldLabel(FieldTerm.memo),
               ),
             ),
           ],
@@ -526,19 +564,3 @@ class _EditableEntryCard extends StatelessWidget {
     );
   }
 }
-
-class _TransactionTypeOption {
-  const _TransactionTypeOption(this.value, this.label);
-
-  final String value;
-  final String label;
-}
-
-const List<_TransactionTypeOption> _transactionTypeOptions =
-    <_TransactionTypeOption>[
-  _TransactionTypeOption('income', '収入'),
-  _TransactionTypeOption('expense', '支出'),
-  _TransactionTypeOption('transfer', '振替'),
-  _TransactionTypeOption('credit_expense', 'カード支出'),
-  _TransactionTypeOption('liability_payment', '負債返済'),
-];

--- a/lib/widgets/term_label.dart
+++ b/lib/widgets/term_label.dart
@@ -1,0 +1,217 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../app/chobo_providers.dart';
+import '../core/terminology_labels.dart';
+
+class TermLabel extends ConsumerWidget {
+  const TermLabel({
+    super.key,
+    required this.label,
+    this.style,
+    this.tooltipEnabled = true,
+  });
+
+  final String label;
+  final TextStyle? style;
+  final bool tooltipEnabled;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final termService = ref.watch(terminologyServiceProvider);
+    final tooltip = tooltipEnabled ? termService.getTooltip(label) : null;
+
+    final text = Text(
+      label,
+      style: style,
+    );
+
+    if (tooltip == null) {
+      return text;
+    }
+
+    return Tooltip(
+      message: tooltip,
+      child: text,
+    );
+  }
+}
+
+class TermTransactionLabel extends ConsumerWidget {
+  const TermTransactionLabel({
+    super.key,
+    required this.transactionType,
+    this.style,
+    this.showTooltip = true,
+  });
+
+  final String transactionType;
+  final TextStyle? style;
+  final bool showTooltip;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final termService = ref.watch(terminologyServiceProvider);
+    final label = termService.getTransactionLabelForType(transactionType);
+    final tooltip = showTooltip ? termService.getTooltip(label) : null;
+
+    final text = Text(
+      label,
+      style: style,
+    );
+
+    if (tooltip == null) {
+      return text;
+    }
+
+    return Tooltip(
+      message: tooltip,
+      child: text,
+    );
+  }
+}
+
+class TermDirectionLabel extends ConsumerWidget {
+  const TermDirectionLabel({
+    super.key,
+    required this.direction,
+    this.style,
+    this.showTooltip = true,
+  });
+
+  final String direction;
+  final TextStyle? style;
+  final bool showTooltip;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final termService = ref.watch(terminologyServiceProvider);
+    final label = termService.getDirectionLabelForDirection(direction);
+    final tooltip = showTooltip ? termService.getTooltip(label) : null;
+
+    final text = Text(
+      label,
+      style: style,
+    );
+
+    if (tooltip == null) {
+      return text;
+    }
+
+    return Tooltip(
+      message: tooltip,
+      child: text,
+    );
+  }
+}
+
+class TermEntryLabel extends ConsumerWidget {
+  const TermEntryLabel({
+    super.key,
+    required this.index,
+    this.style,
+    this.showTooltip = true,
+  });
+
+  final int index;
+  final TextStyle? style;
+  final bool showTooltip;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final termService = ref.watch(terminologyServiceProvider);
+    final label = termService.getEntryLabelForIndex(index);
+    final tooltip = showTooltip ? termService.getTooltip(label) : null;
+
+    final text = Text(
+      label,
+      style: style,
+    );
+
+    if (tooltip == null) {
+      return text;
+    }
+
+    return Tooltip(
+      message: tooltip,
+      child: text,
+    );
+  }
+}
+
+class TermStatusLabel extends ConsumerWidget {
+  const TermStatusLabel({
+    super.key,
+    required this.status,
+    this.style,
+  });
+
+  final String status;
+  final TextStyle? style;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final termService = ref.watch(terminologyServiceProvider);
+    final label = termService.getStatusLabelForStatus(status);
+
+    return Text(
+      label,
+      style: style,
+    );
+  }
+}
+
+class TermAccountName extends ConsumerWidget {
+  const TermAccountName({
+    super.key,
+    required this.englishName,
+    this.style,
+  });
+
+  final String englishName;
+  final TextStyle? style;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final termService = ref.watch(terminologyServiceProvider);
+    final label = termService.getStandardAccountName(englishName);
+
+    return Text(
+      label,
+      style: style,
+    );
+  }
+}
+
+class TermDropdown<T extends Enum> extends ConsumerWidget {
+  const TermDropdown({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    required this.itemBuilder,
+    this.hint,
+  });
+
+  final T value;
+  final ValueChanged<T?> onChanged;
+  final Widget Function(T value, TerminologyService termService) itemBuilder;
+  final String? hint;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final termService = ref.watch(terminologyServiceProvider);
+
+    return DropdownButton<T>(
+      value: value,
+      hint: hint != null ? Text(hint!) : null,
+      isExpanded: true,
+      items: TransactionTerm.values.map((e) {
+        return DropdownMenuItem<T>(
+          value: e as T,
+          child: itemBuilder(e as T, termService),
+        );
+      }).toList(),
+      onChanged: onChanged,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Implements a toggle approach for UI vocabulary with Basic/Advanced modes:

- **Basic mode (default)**: Living-language labels (お金が入った, お金を使った, 入, 出, 出金, 入金)
- **Advanced mode**: Accounting terminology (収入, 支出, 増加, 減少, 借方, 貸方)
- Tooltips in Basic mode explain accounting terms
- Setting toggle in Settings → Display section

## Changes

- Added `TerminologyService` provider for terminology-aware labels
- Updated transaction edit/detail screens
- Updated home screen
- Added toggle UI in settings screen
- Updated documentation

## Issues

- Closes #7 (parent)
- Closes #31 (UI/7.1: living-language input labels)
- Closes #32 (UI/7.2: accounting terminology exposure)

## Files

- `lib/core/terminology_labels.dart` (new)
- `lib/core/terminology_service.dart` (new)
- `lib/widgets/term_label.dart` (new)
- `lib/data/local_db/chobo_records.dart`
- `lib/app/chobo_providers.dart`
- `lib/features/transactions/transaction_edit_screen.dart`
- `lib/features/transactions/transaction_detail_screen.dart`
- `lib/features/home/home_screen.dart`
- `lib/features/home/transaction_list_tile.dart`
- `lib/features/settings/settings_screen.dart`
- `docs/chobo-future-ui-vocab.md`