### PR TITLE
Monthly Summary Feature (Issues #39, #40)

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -5,6 +5,7 @@ import '../features/home/home_screen.dart';
 import '../features/points/points_screen.dart';
 import '../features/recurring/recurring_screen.dart';
 import '../features/settings/settings_screen.dart';
+import '../features/summary/monthly_summary_screen.dart';
 import '../features/transactions/transaction_detail_screen.dart';
 import '../features/transactions/transaction_edit_screen.dart';
 
@@ -29,6 +30,14 @@ final GoRouter choboRouter = GoRouter(
     GoRoute(
       path: '/recurring',
       builder: (context, state) => const RecurringScreen(),
+    ),
+    GoRoute(
+      path: '/summary/:month',
+      builder: (context, state) {
+        return MonthlySummaryScreen(
+          month: state.pathParameters['month']!,
+        );
+      },
     ),
     GoRoute(
       path: '/transactions/:transactionId',

--- a/lib/data/repository/ledger_repository.dart
+++ b/lib/data/repository/ledger_repository.dart
@@ -65,16 +65,25 @@ class LedgerRepository {
         _addTotal(transferTotals, accountName, amount);
       }
 
+      // cashOutExpenses: Direct payments from asset accounts.
+      // Example: Paying groceries with bank debit card.
+      // Formula: expense transaction + asset account decreased.
+      // NOTE: This is NOT credit card charges (see accruedExpenses).
       if (transactionType == 'expense' &&
           accountKind == 'asset' &&
           direction == 'decrease') {
         cashOutExpenses += amount;
       }
 
+      // accruedExpenses: Credit card charges (unpaid at month end).
+      // These will become cash-out when card bill is paid.
+      // Formula: credit_expense transaction.
       if (transactionType == 'credit_expense' && accountKind == 'expense') {
         accruedExpenses += amount;
       }
 
+      // cardPayment: Paying off credit card balance.
+      // Formula: liability_payment transaction + liability account decreased.
       if (transactionType == 'liability_payment' &&
           accountKind == 'liability' &&
           direction == 'decrease') {

--- a/lib/data/service/monthly_summary_dto.dart
+++ b/lib/data/service/monthly_summary_dto.dart
@@ -22,19 +22,49 @@ class MonthlySummaryDto {
 
   final String month;
   final String periodLabel;
+
+  /// Total assets at the start of the month (day 1).
   final int assetsStart;
+
+  /// Total assets at the end of the month.
   final int assetsEnd;
+
+  /// Total liabilities at the start of the month (day 1).
   final int liabilitiesStart;
+
+  /// Total liabilities at the end of the month.
+  /// Includes credit card balances and other payables.
   final int liabilitiesEnd;
+
+  /// Net assets at month start: assetsStart - liabilitiesStart.
   final int netAssetsStart;
+
+  /// Net assets at month end: assetsEnd - liabilitiesEnd.
   final int netAssetsEnd;
+
   final List<MonthlySummaryCategoryTotalDto> expenseItems;
   final List<MonthlySummaryCategoryTotalDto> incomeItems;
   final List<MonthlySummaryCategoryTotalDto> transferItems;
+
+  /// Expenses paid directly from asset accounts (cash/bank outflows).
+  /// Formula: expense transactions where offsetting entry decreases an asset.
+  /// NOTE: Card charges are NOT included here (see accruedExpenses).
   final int cashOutExpenses;
+
+  /// Credit card charges not yet paid to the card company.
+  /// Formula: credit_expense transactions.
+  /// These become cash-out when the card bill is paid.
   final int accruedExpenses;
+
+  /// Total unpaid liability balance at month end.
+  /// Formula: sum of all liability account balances.
+  /// Represents the amount needed to settle all liabilities.
   final int liabilityDue;
+
+  /// Amount paid to reduce liability accounts (e.g., credit card payment).
+  /// Formula: liability_payment transactions.
   final int cardPayment;
+
   final List<MonthlySummarySectionDto> sections;
   final List<MonthlySummaryCardDto> cards;
 

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -70,6 +70,9 @@ class _QuickActionsBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final now = DateTime.now();
+    final month = '${now.year}-${now.month.toString().padLeft(2, '0')}';
+
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Row(
@@ -79,6 +82,14 @@ class _QuickActionsBar extends StatelessWidget {
               icon: Icons.stars,
               label: 'ポイント',
               onTap: () => context.push('/points'),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: _QuickActionButton(
+              icon: Icons.bar_chart,
+              label: '月次',
+              onTap: () => context.push('/summary/$month'),
             ),
           ),
           const SizedBox(width: 8),

--- a/lib/features/summary/monthly_summary_screen.dart
+++ b/lib/features/summary/monthly_summary_screen.dart
@@ -1,0 +1,304 @@
+import 'package:chobo/data/service/monthly_summary_dto.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../app/chobo_providers.dart';
+import 'summary_charts.dart';
+
+final monthlySummaryProvider =
+    FutureProvider.family<MonthlySummaryDto, String>((ref, month) async {
+  final service = ref.watch(monthlySummaryServiceProvider);
+  return service.getMonthlySummary(month);
+});
+
+class MonthlySummaryScreen extends ConsumerWidget {
+  const MonthlySummaryScreen({
+    super.key,
+    required this.month,
+  });
+
+  final String month;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final summaryAsync = ref.watch(monthlySummaryProvider(month));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(summaryAsync.valueOrNull?.periodLabel ?? '月次集計'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.pop(),
+        ),
+      ),
+      body: summaryAsync.when(
+        data: (summary) => _buildContent(context, summary),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, stackTrace) => Center(
+          child: Text('月次集計の読み込みに失敗しました: $error'),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context, MonthlySummaryDto summary) {
+    return ListView(
+      padding: const EdgeInsets.only(bottom: 32),
+      children: [
+        _buildQuickStats(context, summary),
+        const Divider(),
+        _buildCashFlowSection(context, summary),
+        const Divider(),
+        _buildExpensesChart(context, summary),
+        const Divider(),
+        _buildNetAssetsTrend(context, summary),
+        const Divider(),
+        SummaryCardsSection(sections: summary.sections),
+      ],
+    );
+  }
+
+  Widget _buildQuickStats(BuildContext context, MonthlySummaryDto summary) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        children: [
+          Expanded(
+            child: _StatCard(
+              title: '総資産',
+              value: summary.assetsEnd,
+              subtitle:
+                  '(${_formatDelta(summary.assetsEnd - summary.assetsStart)})',
+              color: Colors.blue,
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: _StatCard(
+              title: '純資産',
+              value: summary.netAssetsEnd,
+              subtitle: '(${_formatDelta(summary.netAssetsDelta)})',
+              color: summary.netAssetsDelta >= 0 ? Colors.green : Colors.red,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCashFlowSection(
+      BuildContext context, MonthlySummaryDto summary) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'キャッシュフロー',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 16),
+          CashFlowBarChart(
+            cashOutExpenses: summary.cashOutExpenses,
+            accruedExpenses: summary.accruedExpenses,
+            cardPayment: summary.cardPayment,
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              Expanded(
+                child: _FlowLegendItem(
+                  color: Colors.red,
+                  label: 'Cash-out',
+                  value: summary.cashOutExpenses,
+                ),
+              ),
+              Expanded(
+                child: _FlowLegendItem(
+                  color: Colors.orange,
+                  label: 'Accrued',
+                  value: summary.accruedExpenses,
+                ),
+              ),
+              Expanded(
+                child: _FlowLegendItem(
+                  color: Colors.green,
+                  label: 'Card Pay',
+                  value: summary.cardPayment,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildExpensesChart(BuildContext context, MonthlySummaryDto summary) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '支出内訳',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 16),
+          ExpensePieChart(expenseItems: summary.expenseItems),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNetAssetsTrend(BuildContext context, MonthlySummaryDto summary) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '純資産推移',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 16),
+          NetAssetsTrendChart(
+            netAssetsStart: summary.netAssetsStart,
+            netAssetsEnd: summary.netAssetsEnd,
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatAmount(int amount) {
+    if (amount == 0) return '¥0';
+    final isNegative = amount < 0;
+    final absAmount = amount.abs();
+    final formatted = absAmount.toString().replaceAllMapped(
+          RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
+          (Match m) => '${m[1]},',
+        );
+    return isNegative ? '-¥$formatted' : '¥$formatted';
+  }
+
+  String _formatDelta(int delta) {
+    if (delta == 0) return '±0';
+    final isNegative = delta < 0;
+    final absDelta = delta.abs();
+    final formatted = absDelta.toString().replaceAllMapped(
+          RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
+          (Match m) => '${m[1]},',
+        );
+    return isNegative ? '-$formatted' : '+$formatted';
+  }
+}
+
+class _StatCard extends StatelessWidget {
+  const _StatCard({
+    required this.title,
+    required this.value,
+    required this.subtitle,
+    required this.color,
+  });
+
+  final String title;
+  final int value;
+  final String subtitle;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withOpacity(0.3)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Colors.grey[600],
+                ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            _formatAmount(value),
+            style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  color: color,
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            subtitle,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Colors.grey[500],
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatAmount(int amount) {
+    if (amount == 0) return '¥0';
+    final isNegative = amount < 0;
+    final absAmount = amount.abs();
+    final formatted = absAmount.toString().replaceAllMapped(
+          RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
+          (Match m) => '${m[1]},',
+        );
+    return isNegative ? '-¥$formatted' : '¥$formatted';
+  }
+}
+
+class _FlowLegendItem extends StatelessWidget {
+  const _FlowLegendItem({
+    required this.color,
+    required this.label,
+    required this.value,
+  });
+
+  final Color color;
+  final String label;
+  final int value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 12,
+          height: 12,
+          decoration: BoxDecoration(
+            color: color,
+            shape: BoxShape.circle,
+          ),
+        ),
+        const SizedBox(width: 4),
+        Text(
+          '$label: ${_formatAmount(value)}',
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+      ],
+    );
+  }
+
+  String _formatAmount(int amount) {
+    if (amount == 0) return '¥0';
+    final isNegative = amount < 0;
+    final absAmount = amount.abs();
+    final formatted = absAmount.toString().replaceAllMapped(
+          RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
+          (Match m) => '${m[1]},',
+        );
+    return isNegative ? '-¥$formatted' : '¥$formatted';
+  }
+}

--- a/lib/features/summary/summary_charts.dart
+++ b/lib/features/summary/summary_charts.dart
@@ -1,0 +1,439 @@
+import 'package:chobo/data/service/monthly_summary_dto.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+class SummaryCardsSection extends StatelessWidget {
+  const SummaryCardsSection({
+    super.key,
+    required this.sections,
+  });
+
+  final List<MonthlySummarySectionDto> sections;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: sections.map((section) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+              child: Text(
+                section.title,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+            ),
+            SizedBox(
+              height: 100,
+              child: ListView.builder(
+                scrollDirection: Axis.horizontal,
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                itemCount: section.cards.length,
+                itemBuilder: (context, index) {
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 4),
+                    child: _MetricCard(card: section.cards[index]),
+                  );
+                },
+              ),
+            ),
+          ],
+        );
+      }).toList(),
+    );
+  }
+}
+
+class _MetricCard extends StatelessWidget {
+  const _MetricCard({required this.card});
+
+  final MonthlySummaryCardDto card;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = _toneToColor(card.tone);
+
+    return Container(
+      width: 140,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withOpacity(0.3)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            card.title,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Colors.grey[600],
+                ),
+            overflow: TextOverflow.ellipsis,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            _formatAmount(card.value),
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  color: color,
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+          if (card.subtitle != null) ...[
+            const SizedBox(height: 2),
+            Text(
+              card.subtitle!,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Colors.grey[500],
+                  ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Color _toneToColor(String tone) {
+    switch (tone) {
+      case 'positive':
+        return Colors.green;
+      case 'negative':
+        return Colors.red;
+      default:
+        return Colors.blue;
+    }
+  }
+
+  String _formatAmount(int amount) {
+    if (amount == 0) return '¥0';
+    final isNegative = amount < 0;
+    final absAmount = amount.abs();
+    final formatted = absAmount.toString().replaceAllMapped(
+          RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
+          (Match m) => '${m[1]},',
+        );
+    return isNegative ? '-¥$formatted' : '¥$formatted';
+  }
+}
+
+class ExpensePieChart extends StatelessWidget {
+  const ExpensePieChart({
+    super.key,
+    required this.expenseItems,
+  });
+
+  final List<MonthlySummaryCategoryTotalDto> expenseItems;
+
+  static const _colors = [
+    Color(0xFF6750A4),
+    Color(0xFF625B71),
+    Color(0xFF7D5260),
+    Color(0xFFB3261E),
+    Color(0xFFEF6C00),
+    Color(0xFF2E7D32),
+    Color(0xFF1565C0),
+    Color(0xFF6A1B9A),
+    Color(0xFF00838F),
+    Color(0xFF4E342E),
+    Color(0xFF37474F),
+    Color(0xFF558B2F),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    if (expenseItems.isEmpty) {
+      return const Center(child: Text('支出データがありません'));
+    }
+
+    final total = expenseItems.fold<int>(0, (sum, item) => sum + item.amount);
+
+    return Column(
+      children: [
+        SizedBox(
+          height: 200,
+          child: PieChart(
+            PieChartData(
+              sectionsSpace: 2,
+              centerSpaceRadius: 40,
+              sections: _buildSections(total),
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+        _buildLegend(context, total),
+      ],
+    );
+  }
+
+  List<PieChartSectionData> _buildSections(int total) {
+    return expenseItems.asMap().entries.map((entry) {
+      final index = entry.key;
+      final item = entry.value;
+      final percentage = (item.amount / total * 100);
+      final color = _colors[index % _colors.length];
+
+      return PieChartSectionData(
+        color: color,
+        value: item.amount.toDouble(),
+        title: '${percentage.toStringAsFixed(0)}%',
+        radius: 60,
+        titleStyle: const TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.bold,
+          color: Colors.white,
+        ),
+      );
+    }).toList();
+  }
+
+  Widget _buildLegend(BuildContext context, int total) {
+    return Wrap(
+      spacing: 16,
+      runSpacing: 8,
+      children: expenseItems.asMap().entries.map((entry) {
+        final index = entry.key;
+        final item = entry.value;
+        final color = _colors[index % _colors.length];
+
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 12,
+              height: 12,
+              decoration: BoxDecoration(
+                color: color,
+                shape: BoxShape.circle,
+              ),
+            ),
+            const SizedBox(width: 4),
+            Text(
+              '${item.label} (${(item.amount / total * 100).toStringAsFixed(0)}%)',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ],
+        );
+      }).toList(),
+    );
+  }
+}
+
+class CashFlowBarChart extends StatelessWidget {
+  const CashFlowBarChart({
+    super.key,
+    required this.cashOutExpenses,
+    required this.accruedExpenses,
+    required this.cardPayment,
+  });
+
+  final int cashOutExpenses;
+  final int accruedExpenses;
+  final int cardPayment;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 200,
+      child: BarChart(
+        BarChartData(
+          alignment: BarChartAlignment.spaceAround,
+          maxY: _calculateMaxY(),
+          barGroups: _buildBarGroups(),
+          titlesData: FlTitlesData(
+            show: true,
+            bottomTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                getTitlesWidget: _getBottomTitles,
+                reservedSize: 30,
+              ),
+            ),
+            leftTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                getTitlesWidget: _getLeftTitles,
+                reservedSize: 50,
+              ),
+            ),
+            topTitles:
+                const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            rightTitles:
+                const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+          ),
+          borderData: FlBorderData(show: false),
+          gridData: const FlGridData(show: false),
+        ),
+      ),
+    );
+  }
+
+  double _calculateMaxY() {
+    final max = [cashOutExpenses, accruedExpenses, cardPayment]
+        .reduce((a, b) => a > b ? a : b);
+    return (max * 1.2).toDouble();
+  }
+
+  List<BarChartGroupData> _buildBarGroups() {
+    return [
+      BarChartGroupData(
+        x: 0,
+        barRods: [
+          BarChartRodData(
+            toY: cashOutExpenses.toDouble(),
+            color: Colors.red,
+            width: 20,
+            borderRadius: const BorderRadius.only(
+              topLeft: Radius.circular(4),
+              topRight: Radius.circular(4),
+            ),
+          ),
+        ],
+      ),
+      BarChartGroupData(
+        x: 1,
+        barRods: [
+          BarChartRodData(
+            toY: accruedExpenses.toDouble(),
+            color: Colors.orange,
+            width: 20,
+            borderRadius: const BorderRadius.only(
+              topLeft: Radius.circular(4),
+              topRight: Radius.circular(4),
+            ),
+          ),
+        ],
+      ),
+      BarChartGroupData(
+        x: 2,
+        barRods: [
+          BarChartRodData(
+            toY: cardPayment.toDouble(),
+            color: Colors.green,
+            width: 20,
+            borderRadius: const BorderRadius.only(
+              topLeft: Radius.circular(4),
+              topRight: Radius.circular(4),
+            ),
+          ),
+        ],
+      ),
+    ];
+  }
+
+  Widget _getBottomTitles(double value, TitleMeta meta) {
+    const titles = ['Cash-out', 'Accrued', 'Card Pay'];
+    final index = value.toInt();
+    if (index >= 0 && index < titles.length) {
+      return SideTitleWidget(
+        axisSide: meta.axisSide,
+        child: Text(
+          titles[index],
+          style: const TextStyle(fontSize: 10),
+        ),
+      );
+    }
+    return const SizedBox();
+  }
+
+  Widget _getLeftTitles(double value, TitleMeta meta) {
+    return SideTitleWidget(
+      axisSide: meta.axisSide,
+      child: Text(
+        _formatAxisValue(value.toInt()),
+        style: const TextStyle(fontSize: 10),
+      ),
+    );
+  }
+
+  String _formatAxisValue(int value) {
+    if (value >= 1000000) {
+      return '${(value / 1000000).toStringAsFixed(1)}M';
+    } else if (value >= 1000) {
+      return '${(value / 1000).toStringAsFixed(0)}K';
+    }
+    return value.toString();
+  }
+}
+
+class NetAssetsTrendChart extends StatelessWidget {
+  const NetAssetsTrendChart({
+    super.key,
+    required this.netAssetsStart,
+    required this.netAssetsEnd,
+  });
+
+  final int netAssetsStart;
+  final int netAssetsEnd;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 150,
+      child: LineChart(
+        LineChartData(
+          lineBarsData: [
+            LineChartBarData(
+              spots: [
+                FlSpot(0, netAssetsStart.toDouble()),
+                FlSpot(1, netAssetsEnd.toDouble()),
+              ],
+              isCurved: false,
+              color: Colors.blue,
+              barWidth: 3,
+              dotData: const FlDotData(show: true),
+              belowBarData: BarAreaData(
+                show: true,
+                color: Colors.blue.withOpacity(0.2),
+              ),
+            ),
+          ],
+          titlesData: FlTitlesData(
+            show: true,
+            bottomTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                getTitlesWidget: (value, meta) {
+                  if (value == 0) return const Text('Start');
+                  if (value == 1) return const Text('End');
+                  return const SizedBox();
+                },
+                reservedSize: 30,
+              ),
+            ),
+            leftTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                getTitlesWidget: (value, meta) {
+                  return Text(
+                    _formatAxisValue(value.toInt()),
+                    style: const TextStyle(fontSize: 10),
+                  );
+                },
+                reservedSize: 50,
+              ),
+            ),
+            topTitles:
+                const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            rightTitles:
+                const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+          ),
+          borderData: FlBorderData(show: false),
+          gridData: const FlGridData(show: false),
+        ),
+      ),
+    );
+  }
+
+  String _formatAxisValue(int value) {
+    if (value >= 1000000) {
+      return '${(value / 1000000).toStringAsFixed(1)}M';
+    } else if (value >= 1000) {
+      return '${(value / 1000).toStringAsFixed(0)}K';
+    }
+    return value.toString();
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -129,6 +129,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.0"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.8"
   fake_async:
     dependency: transitive
     description:
@@ -161,6 +169,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.3.7"
+  fl_chart:
+    dependency: "direct main"
+    description:
+      name: fl_chart
+      sha256: "74959b99b92b9eebeed1a4049426fd67c4abc3c5a0f4d12e2877097d6a11ae08"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.69.2"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   pointycastle: ^3.9.1
   sqlite3: ^3.2.0
   package_info_plus: ^8.0.0
+  fl_chart: ^0.69.0
 
 dev_dependencies:
   flutter_test:

--- a/test/data/service/monthly_summary_service_test.dart
+++ b/test/data/service/monthly_summary_service_test.dart
@@ -8,57 +8,423 @@ import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('delegates monthly summary and balance lookups to the ledger repo',
-      () async {
-    final db = _openDb();
-    addTearDown(db.close);
+  group('MonthlySummaryService', () {
+    test('delegates monthly summary and balance lookups to the ledger repo',
+        () async {
+      final db = _openDb();
+      addTearDown(db.close);
 
-    final accounts = AccountRepository(db);
-    final transactions = TransactionRepository(db);
-    final service = MonthlySummaryService(LedgerRepository(db));
+      final accounts = AccountRepository(db);
+      final transactions = TransactionRepository(db);
+      final service = MonthlySummaryService(LedgerRepository(db));
 
-    await accounts.createAccount(
-      _sampleAccount(accountId: 'asset:bank:main', name: 'Main Bank'),
-    );
-    await accounts.createAccount(
-      _sampleAccount(accountId: 'expense:food', name: 'Food'),
-    );
+      await accounts.createAccount(
+        _sampleAccount(accountId: 'asset:bank:main', name: 'Main Bank'),
+      );
+      await accounts.createAccount(
+        _sampleAccount(accountId: 'expense:food', name: 'Food'),
+      );
 
-    await transactions.createTransaction(
-      _sampleTransaction(transactionId: 'txn_001', date: '2026-03-05'),
-      <ChoboEntryRecord>[
-        const ChoboEntryRecord(
-          entryId: 'ent_001',
+      await transactions.createTransaction(
+        _sampleTransaction(transactionId: 'txn_001', date: '2026-03-05'),
+        <ChoboEntryRecord>[
+          const ChoboEntryRecord(
+            entryId: 'ent_001',
+            transactionId: 'txn_001',
+            accountId: 'asset:bank:main',
+            direction: 'decrease',
+            amount: 1200,
+          ),
+          const ChoboEntryRecord(
+            entryId: 'ent_002',
+            transactionId: 'txn_001',
+            accountId: 'expense:food',
+            direction: 'increase',
+            amount: 1200,
+          ),
+        ],
+      );
+
+      final summary = await service.getMonthlySummary('2026-03');
+      expect(summary.month, '2026-03');
+      expect(summary.periodLabel, '2026年03月');
+      expect(summary.cashOutExpenses, 1200);
+      expect(summary.sections, hasLength(5));
+      expect(summary.cards.length, greaterThanOrEqualTo(7));
+      expect(summary.sections.first.key, 'overview');
+      expect(summary.sections.first.cards.first.title, 'Assets');
+      expect(summary.sections[2].title, 'Expenses');
+      expect(summary.sections[2].cards.single.key, 'Food');
+      expect(summary.sections[2].cards.single.title, 'Food');
+
+      final balances = await service.getAccountBalances();
+      expect(balances['asset:bank:main'], -1200);
+      expect(balances['expense:food'], 1200);
+    });
+
+    test('calculates cash-out expenses correctly for direct payments',
+        () async {
+      final db = _openDb();
+      addTearDown(db.close);
+
+      final accounts = AccountRepository(db);
+      final transactions = TransactionRepository(db);
+      final service = MonthlySummaryService(LedgerRepository(db));
+
+      await accounts.createAccount(
+        _sampleAccount(accountId: 'asset:bank:main', name: 'Main Bank'),
+      );
+      await accounts.createAccount(
+        _sampleAccount(accountId: 'expense:food', name: 'Food'),
+      );
+
+      await transactions.createTransaction(
+        _sampleTransaction(transactionId: 'txn_001', date: '2026-03-05'),
+        <ChoboEntryRecord>[
+          const ChoboEntryRecord(
+            entryId: 'ent_001',
+            transactionId: 'txn_001',
+            accountId: 'asset:bank:main',
+            direction: 'decrease',
+            amount: 5000,
+          ),
+          const ChoboEntryRecord(
+            entryId: 'ent_002',
+            transactionId: 'txn_001',
+            accountId: 'expense:food',
+            direction: 'increase',
+            amount: 5000,
+          ),
+        ],
+      );
+
+      final summary = await service.getMonthlySummary('2026-03');
+      expect(summary.cashOutExpenses, 5000);
+      expect(summary.accruedExpenses, 0);
+    });
+
+    test('calculates accrued expenses for credit card charges', () async {
+      final db = _openDb();
+      addTearDown(db.close);
+
+      final accounts = AccountRepository(db);
+      final transactions = TransactionRepository(db);
+      final service = MonthlySummaryService(LedgerRepository(db));
+
+      await accounts.createAccount(
+        _sampleAccount(accountId: 'asset:bank:main', name: 'Main Bank'),
+      );
+      await accounts.createAccount(
+        _sampleAccount(accountId: 'expense:food', name: 'Food'),
+      );
+      await accounts.createAccount(
+        _sampleAccount(accountId: 'liability:card:main', name: 'Card'),
+      );
+
+      await transactions.createTransaction(
+        _sampleTransaction(
           transactionId: 'txn_001',
-          accountId: 'asset:bank:main',
-          direction: 'decrease',
-          amount: 1200,
+          date: '2026-03-05',
+          type: 'credit_expense',
         ),
-        const ChoboEntryRecord(
-          entryId: 'ent_002',
-          transactionId: 'txn_001',
-          accountId: 'expense:food',
-          direction: 'increase',
-          amount: 1200,
+        <ChoboEntryRecord>[
+          const ChoboEntryRecord(
+            entryId: 'ent_001',
+            transactionId: 'txn_001',
+            accountId: 'liability:card:main',
+            direction: 'increase',
+            amount: 3000,
+          ),
+          const ChoboEntryRecord(
+            entryId: 'ent_002',
+            transactionId: 'txn_001',
+            accountId: 'expense:food',
+            direction: 'increase',
+            amount: 3000,
+          ),
+        ],
+      );
+
+      final summary = await service.getMonthlySummary('2026-03');
+      expect(summary.cashOutExpenses, 0);
+      expect(summary.accruedExpenses, 3000);
+      expect(summary.liabilityDue, 3000);
+    });
+
+    test('calculates card payment when paying credit card bill', () async {
+      final db = _openDb();
+      addTearDown(db.close);
+
+      final accounts = AccountRepository(db);
+      final transactions = TransactionRepository(db);
+      final service = MonthlySummaryService(LedgerRepository(db));
+
+      await accounts.createAccount(
+        _sampleAccount(accountId: 'asset:bank:main', name: 'Main Bank'),
+      );
+      await accounts.createAccount(
+        _sampleAccount(accountId: 'expense:food', name: 'Food'),
+      );
+      await accounts.createAccount(
+        _sampleAccount(accountId: 'liability:card:main', name: 'Card'),
+      );
+
+      await transactions.createTransaction(
+        _sampleTransaction(
+          transactionId: 'txn_credit',
+          date: '2026-03-05',
+          type: 'credit_expense',
         ),
-      ],
-    );
+        <ChoboEntryRecord>[
+          const ChoboEntryRecord(
+            entryId: 'ent_credit_card',
+            transactionId: 'txn_credit',
+            accountId: 'liability:card:main',
+            direction: 'increase',
+            amount: 3000,
+          ),
+          const ChoboEntryRecord(
+            entryId: 'ent_credit_food',
+            transactionId: 'txn_credit',
+            accountId: 'expense:food',
+            direction: 'increase',
+            amount: 3000,
+          ),
+        ],
+      );
 
-    final summary = await service.getMonthlySummary('2026-03');
-    expect(summary.month, '2026-03');
-    expect(summary.periodLabel, '2026年03月');
-    expect(summary.cashOutExpenses, 1200);
-    expect(summary.sections, hasLength(5));
-    expect(summary.cards.length, greaterThanOrEqualTo(7));
-    expect(summary.sections.first.key, 'overview');
-    expect(summary.sections.first.cards.first.title, 'Assets');
-    expect(summary.sections[2].title, 'Expenses');
-    expect(summary.sections[2].cards.single.key, 'Food');
-    expect(summary.sections[2].cards.single.title, 'Food');
+      await transactions.createTransaction(
+        _sampleTransaction(
+          transactionId: 'txn_payment',
+          date: '2026-03-20',
+          type: 'liability_payment',
+        ),
+        <ChoboEntryRecord>[
+          const ChoboEntryRecord(
+            entryId: 'ent_payment_bank',
+            transactionId: 'txn_payment',
+            accountId: 'asset:bank:main',
+            direction: 'decrease',
+            amount: 3000,
+          ),
+          const ChoboEntryRecord(
+            entryId: 'ent_payment_card',
+            transactionId: 'txn_payment',
+            accountId: 'liability:card:main',
+            direction: 'decrease',
+            amount: 3000,
+          ),
+        ],
+      );
 
-    final balances = await service.getAccountBalances();
-    expect(balances['asset:bank:main'], -1200);
-    expect(balances['expense:food'], 1200);
+      final summary = await service.getMonthlySummary('2026-03');
+      expect(summary.accruedExpenses, 3000);
+      expect(summary.cardPayment, 3000);
+      expect(summary.liabilityDue, 0);
+    });
+
+    test('calculates net assets delta correctly', () async {
+      final db = _openDb();
+      addTearDown(db.close);
+
+      final accounts = AccountRepository(db);
+      final transactions = TransactionRepository(db);
+      final service = MonthlySummaryService(LedgerRepository(db));
+
+      await accounts.createAccount(
+        _sampleAccount(accountId: 'asset:bank:main', name: 'Main Bank'),
+      );
+      await accounts.createAccount(
+        _sampleAccount(accountId: 'liability:card:main', name: 'Card'),
+      );
+      await accounts.createAccount(
+        _sampleAccount(accountId: 'income:salary', name: 'Salary'),
+      );
+
+      await transactions.createTransaction(
+        _sampleTransaction(
+          transactionId: 'txn_salary',
+          date: '2026-03-15',
+          type: 'income',
+        ),
+        <ChoboEntryRecord>[
+          const ChoboEntryRecord(
+            entryId: 'ent_salary_bank',
+            transactionId: 'txn_salary',
+            accountId: 'asset:bank:main',
+            direction: 'increase',
+            amount: 300000,
+          ),
+          const ChoboEntryRecord(
+            entryId: 'ent_salary_income',
+            transactionId: 'txn_salary',
+            accountId: 'income:salary',
+            direction: 'increase',
+            amount: 300000,
+          ),
+        ],
+      );
+
+      final summary = await service.getMonthlySummary('2026-03');
+      expect(summary.assetsStart, 0);
+      expect(summary.assetsEnd, 300000);
+      expect(summary.liabilitiesStart, 0);
+      expect(summary.liabilitiesEnd, 0);
+      expect(summary.netAssetsStart, 0);
+      expect(summary.netAssetsEnd, 300000);
+      expect(summary.netAssetsDelta, 300000);
+    });
+
+    test('handles month with no transactions', () async {
+      final db = _openDb();
+      addTearDown(db.close);
+
+      final accounts = AccountRepository(db);
+      final service = MonthlySummaryService(LedgerRepository(db));
+
+      await accounts.createAccount(
+        _sampleAccount(accountId: 'asset:bank:main', name: 'Main Bank'),
+      );
+      await accounts.createAccount(
+        _sampleAccount(accountId: 'liability:card:main', name: 'Card'),
+      );
+
+      final summary = await service.getMonthlySummary('2026-03');
+      expect(summary.month, '2026-03');
+      expect(summary.assetsStart, 0);
+      expect(summary.assetsEnd, 0);
+      expect(summary.liabilitiesStart, 0);
+      expect(summary.liabilitiesEnd, 0);
+      expect(summary.cashOutExpenses, 0);
+      expect(summary.accruedExpenses, 0);
+      expect(summary.liabilityDue, 0);
+      expect(summary.cardPayment, 0);
+      expect(summary.expenseItems, isEmpty);
+      expect(summary.incomeItems, isEmpty);
+    });
+
+    test('separates cash-out from accrued expenses correctly', () async {
+      final db = _openDb();
+      addTearDown(db.close);
+
+      final accounts = AccountRepository(db);
+      final transactions = TransactionRepository(db);
+      final service = MonthlySummaryService(LedgerRepository(db));
+
+      await accounts.createAccount(
+        _sampleAccount(accountId: 'asset:bank:main', name: 'Main Bank'),
+      );
+      await accounts.createAccount(
+        _sampleAccount(accountId: 'expense:food', name: 'Food'),
+      );
+      await accounts.createAccount(
+        _sampleAccount(accountId: 'expense:transport', name: 'Transport'),
+      );
+      await accounts.createAccount(
+        _sampleAccount(accountId: 'liability:card:main', name: 'Card'),
+      );
+
+      await transactions.createTransaction(
+        _sampleTransaction(transactionId: 'txn_cash', date: '2026-03-05'),
+        <ChoboEntryRecord>[
+          const ChoboEntryRecord(
+            entryId: 'ent_cash_bank',
+            transactionId: 'txn_cash',
+            accountId: 'asset:bank:main',
+            direction: 'decrease',
+            amount: 1000,
+          ),
+          const ChoboEntryRecord(
+            entryId: 'ent_cash_food',
+            transactionId: 'txn_cash',
+            accountId: 'expense:food',
+            direction: 'increase',
+            amount: 1000,
+          ),
+        ],
+      );
+
+      await transactions.createTransaction(
+        _sampleTransaction(
+          transactionId: 'txn_card',
+          date: '2026-03-10',
+          type: 'credit_expense',
+        ),
+        <ChoboEntryRecord>[
+          const ChoboEntryRecord(
+            entryId: 'ent_card_liability',
+            transactionId: 'txn_card',
+            accountId: 'liability:card:main',
+            direction: 'increase',
+            amount: 2000,
+          ),
+          const ChoboEntryRecord(
+            entryId: 'ent_card_transport',
+            transactionId: 'txn_card',
+            accountId: 'expense:transport',
+            direction: 'increase',
+            amount: 2000,
+          ),
+        ],
+      );
+
+      final summary = await service.getMonthlySummary('2026-03');
+      expect(summary.cashOutExpenses, 1000);
+      expect(summary.accruedExpenses, 2000);
+      expect(summary.expenseItems.length, 2);
+    });
+
+    test('sections contain correct keys and structure', () async {
+      final db = _openDb();
+      addTearDown(db.close);
+
+      final accounts = AccountRepository(db);
+      final transactions = TransactionRepository(db);
+      final service = MonthlySummaryService(LedgerRepository(db));
+
+      await accounts.createAccount(
+        _sampleAccount(accountId: 'asset:bank:main', name: 'Main Bank'),
+      );
+      await accounts.createAccount(
+        _sampleAccount(accountId: 'expense:food', name: 'Food'),
+      );
+
+      await transactions.createTransaction(
+        _sampleTransaction(transactionId: 'txn_001', date: '2026-03-05'),
+        <ChoboEntryRecord>[
+          const ChoboEntryRecord(
+            entryId: 'ent_001',
+            transactionId: 'txn_001',
+            accountId: 'asset:bank:main',
+            direction: 'decrease',
+            amount: 1200,
+          ),
+          const ChoboEntryRecord(
+            entryId: 'ent_002',
+            transactionId: 'txn_001',
+            accountId: 'expense:food',
+            direction: 'increase',
+            amount: 1200,
+          ),
+        ],
+      );
+
+      final summary = await service.getMonthlySummary('2026-03');
+      expect(summary.sections.length, 5);
+      expect(summary.sections[0].key, 'overview');
+      expect(summary.sections[0].title, 'Overview');
+      expect(summary.sections[1].key, 'flow');
+      expect(summary.sections[1].title, 'Cash Flow');
+      expect(summary.sections[2].key, 'expenses');
+      expect(summary.sections[3].key, 'income');
+      expect(summary.sections[4].key, 'transfers');
+
+      final flowSection = summary.sections[1];
+      expect(flowSection.cards.any((c) => c.key == 'cash_out_expenses'), true);
+      expect(flowSection.cards.any((c) => c.key == 'accrued_expenses'), true);
+      expect(flowSection.cards.any((c) => c.key == 'liability_due'), true);
+      expect(flowSection.cards.any((c) => c.key == 'card_payment'), true);
+    });
   });
 }
 
@@ -88,11 +454,12 @@ ChoboAccountRecord _sampleAccount({
 ChoboTransactionRecord _sampleTransaction({
   required String transactionId,
   required String date,
+  String type = 'expense',
 }) {
   return ChoboTransactionRecord(
     transactionId: transactionId,
     date: date,
-    type: 'expense',
+    type: type,
     status: 'posted',
     createdAt: '2026-03-20T09:00:00Z',
     updatedAt: '2026-03-20T09:00:00Z',

--- a/test/features/transactions/transaction_detail_screen_test.dart
+++ b/test/features/transactions/transaction_detail_screen_test.dart
@@ -1,7 +1,9 @@
 import 'package:chobo/app/chobo_providers.dart';
+import 'package:chobo/core/terminology_service.dart';
 import 'package:chobo/data/local_db/app_database.dart';
 import 'package:chobo/data/local_db/chobo_records.dart';
 import 'package:chobo/data/repository/account_repository.dart';
+import 'package:chobo/data/repository/settings_repository.dart';
 import 'package:chobo/data/repository/transaction_repository.dart';
 import 'package:chobo/features/transactions/transaction_detail_screen.dart';
 import 'package:drift/native.dart';
@@ -43,10 +45,15 @@ void main() {
       ],
     );
 
+    final settingsRepo = SettingsRepository(db);
+
     await tester.pumpWidget(
       ProviderScope(
         overrides: <Override>[
           appDatabaseProvider.overrideWithValue(db),
+          terminologyModeProvider.overrideWith(
+            (ref) => _TestTerminologyModeNotifier(settingsRepo),
+          ),
         ],
         child: const MaterialApp(
           home: TransactionDetailScreen(transactionId: 'txn_001'),
@@ -63,6 +70,23 @@ void main() {
     expect(find.text('戻る'), findsOneWidget);
     expect(find.text('編集'), findsOneWidget);
   });
+}
+
+class _TestTerminologyModeNotifier extends TerminologyModeNotifier {
+  _TestTerminologyModeNotifier(SettingsRepository settingsRepo)
+      : super(settingsRepo) {
+    state = 'advanced';
+  }
+
+  @override
+  Future<void> _loadSetting() async {
+    // No-op for testing - already set state in constructor
+  }
+
+  @override
+  Future<void> setMode(String mode) async {
+    state = mode;
+  }
 }
 
 AppDatabase _openDb() {


### PR DESCRIPTION
## Summary

Implements the monthly summary feature for issue #10 and its child issues:

### Issue #39: Cash-out and liability metrics
- Added documentation comments explaining the metric formulas in `ledger_repository.dart`
- Added comprehensive DTO documentation in `monthly_summary_dto.dart`
- Added 8 new tests covering cash-out expenses, accrued expenses, card payments, and edge cases

### Issue #40: Asset movement visualization
- Added `fl_chart` dependency for chart visualizations
- Created monthly summary screen with:
  - Quick stats (total assets, net assets)
  - Cash flow bar chart
  - Expense pie chart breakdown
  - Net assets trend line chart
  - Metric cards by section
- Added `/summary/:month` route
- Added "月次" button to home screen quick actions

### Additional fixes
- Fixed pre-existing widget test failure by properly mocking `TerminologyModeNotifier`

## Commits
- `343b73c` feat(summary): add monthly summary screen with charts
- `efd1105` docs(metrics): document cash-out and liability metric definitions
- `80d7335` test(monthly_summary): add comprehensive tests for cash flow metrics
- `1cbc3c3` fix(test): resolve terminology mode mock in widget test