### PR TITLE
feat(budget): add budget and forecast feature (issues #11, #41, #42, #43)

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -2,12 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
-import '../backup/auto_backup_manager.dart';
 import '../core/app_logger.dart';
+import '../data/local_db/chobo_records.dart';
 import '../data/local_db/database_integrity_checker.dart';
 import 'chobo_app.dart';
 import 'chobo_providers.dart';
 import '../features/recovery/recovery_screen.dart';
+
+const _notificationPermissionRequestedKey = 'notification_permission_requested';
 
 class AppInitializer extends ConsumerStatefulWidget {
   const AppInitializer({super.key});
@@ -85,6 +87,38 @@ class _AppInitializerState extends ConsumerState<AppInitializer> {
     }
   }
 
+  Future<void> _requestNotificationPermission() async {
+    try {
+      final settingsRepo = ref.read(settingsRepositoryProvider);
+      final requested =
+          await settingsRepo.getSetting(_notificationPermissionRequestedKey);
+
+      if (requested == null) {
+        final notificationService = ref.read(notificationServiceProvider);
+        final granted = await notificationService.requestPermissions();
+        await settingsRepo.setSetting(
+          ChoboSettingRecord(
+            settingKey: _notificationPermissionRequestedKey,
+            settingValue: granted ? 'true' : 'denied',
+          ),
+        );
+        AppLogger.log(
+            'Notification permission ${granted ? 'granted' : 'denied'}');
+      }
+    } catch (e, stackTrace) {
+      AppLogger.logError(
+          'Failed to request notification permission', stackTrace);
+      try {
+        await ref.read(settingsRepositoryProvider).setSetting(
+              ChoboSettingRecord(
+                settingKey: _notificationPermissionRequestedKey,
+                settingValue: 'error',
+              ),
+            );
+      } catch (_) {}
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     if (_isChecking) {
@@ -102,6 +136,7 @@ class _AppInitializerState extends ConsumerState<AppInitializer> {
     // Trigger auto-backup after first frame is rendered
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _createAutoBackup();
+      _requestNotificationPermission();
     });
 
     return const ChoboApp();

--- a/lib/app/chobo_providers.dart
+++ b/lib/app/chobo_providers.dart
@@ -24,9 +24,15 @@ import '../data/repository/recurring_template_repository.dart';
 import '../data/repository/settings_repository.dart';
 import '../data/repository/tag_repository.dart';
 import '../data/repository/transaction_repository.dart';
+import '../data/repository/budget_repository.dart';
+import '../data/repository/budget_alert_repository.dart';
 import '../data/service/reconciliation_service.dart';
 import '../data/service/monthly_summary_service.dart';
 import '../data/service/points_calculation_service.dart';
+import '../data/service/budget_service.dart';
+import '../data/service/forecast_service.dart';
+import '../data/service/budget_alert_service.dart';
+import '../data/service/notification_service.dart';
 import '../core/auth_service.dart';
 import '../core/audit_event_factory.dart';
 
@@ -210,4 +216,61 @@ final pointsBalanceProvider =
     FutureProvider.family<ChoboPointsBalanceRecord, String>(
         (ref, pointsAccountId) async {
   return ref.watch(pointsRepositoryProvider).getPointsBalance(pointsAccountId);
+});
+
+final budgetRepositoryProvider = Provider<BudgetRepository>((ref) {
+  return BudgetRepository(ref.watch(appDatabaseProvider));
+});
+
+final budgetAlertRepositoryProvider = Provider<BudgetAlertRepository>((ref) {
+  return BudgetAlertRepository(ref.watch(appDatabaseProvider));
+});
+
+final notificationServiceProvider = Provider<NotificationService>((ref) {
+  return NotificationService();
+});
+
+final budgetServiceProvider = Provider<BudgetService>((ref) {
+  return BudgetService(
+    ref.watch(budgetRepositoryProvider),
+    ref.watch(accountRepositoryProvider),
+    ref.watch(appDatabaseProvider),
+  );
+});
+
+final forecastServiceProvider = Provider<ForecastService>((ref) {
+  return ForecastService(
+    ref.watch(appDatabaseProvider),
+    ref.watch(recurringTemplateRepositoryProvider),
+  );
+});
+
+final budgetAlertServiceProvider = Provider<BudgetAlertService>((ref) {
+  return BudgetAlertService(
+    ref.watch(budgetAlertRepositoryProvider),
+    ref.watch(budgetRepositoryProvider),
+    ref.watch(budgetServiceProvider),
+    ref.watch(notificationServiceProvider),
+  );
+});
+
+final monthlyBudgetProvider =
+    FutureProvider.family<MonthlyBudgetDto, String>((ref, month) async {
+  return ref.watch(budgetServiceProvider).getMonthlyBudget(month);
+});
+
+final budgetComparisonsProvider =
+    FutureProvider.family<List<BudgetComparisonDto>, String>(
+        (ref, month) async {
+  return ref.watch(budgetServiceProvider).getBudgetComparisons(month);
+});
+
+final endOfMonthForecastProvider =
+    FutureProvider.family<EndOfMonthForecastDto, String>((ref, month) async {
+  return ref.watch(forecastServiceProvider).getEndOfMonthForecast(month);
+});
+
+final recentBudgetAlertsProvider =
+    FutureProvider<List<ChoboBudgetAlertRecord>>((ref) async {
+  return ref.watch(budgetAlertServiceProvider).getRecentAlerts();
 });

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -8,6 +8,7 @@ import '../features/settings/settings_screen.dart';
 import '../features/summary/monthly_summary_screen.dart';
 import '../features/transactions/transaction_detail_screen.dart';
 import '../features/transactions/transaction_edit_screen.dart';
+import '../features/budget/budget_screen.dart';
 
 final GoRouter choboRouter = GoRouter(
   routes: <RouteBase>[
@@ -35,6 +36,14 @@ final GoRouter choboRouter = GoRouter(
       path: '/summary/:month',
       builder: (context, state) {
         return MonthlySummaryScreen(
+          month: state.pathParameters['month']!,
+        );
+      },
+    ),
+    GoRoute(
+      path: '/budget/:month',
+      builder: (context, state) {
+        return BudgetScreen(
           month: state.pathParameters['month']!,
         );
       },

--- a/lib/data/local_db/chobo_migration.dart
+++ b/lib/data/local_db/chobo_migration.dart
@@ -50,6 +50,9 @@ class ChoboMigration {
           case 8:
             await _applyVersion8(migrator);
             break;
+          case 9:
+            await _applyVersion9(migrator);
+            break;
           default:
             throw UnsupportedError(
               'Schema migration to v$version is not implemented yet.',
@@ -256,6 +259,51 @@ class ChoboMigration {
     );
     await migrator.database.customStatement(
       'PRAGMA user_version = 8;',
+    );
+  }
+
+  static Future<void> _applyVersion9(Migrator migrator) async {
+    await migrator.database.customStatement(
+      '''
+      CREATE TABLE IF NOT EXISTS budgets (
+        budget_id TEXT PRIMARY KEY,
+        account_id TEXT NOT NULL REFERENCES accounts(account_id) ON UPDATE CASCADE ON DELETE CASCADE,
+        month TEXT NOT NULL,
+        amount INTEGER NOT NULL CHECK (amount >= 0),
+        alert_threshold_percent INTEGER NOT NULL DEFAULT 80 CHECK (alert_threshold_percent >= 0 AND alert_threshold_percent <= 100),
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        UNIQUE(account_id, month)
+      );
+      ''',
+    );
+    await migrator.database.customStatement(
+      '''
+      CREATE TABLE IF NOT EXISTS budget_alerts (
+        alert_id TEXT PRIMARY KEY,
+        budget_id TEXT NOT NULL REFERENCES budgets(budget_id) ON UPDATE CASCADE ON DELETE CASCADE,
+        triggered_at TEXT NOT NULL,
+        actual_amount INTEGER NOT NULL,
+        budget_amount INTEGER NOT NULL,
+        threshold_percent INTEGER NOT NULL,
+        notified INTEGER NOT NULL DEFAULT 0 CHECK (notified IN (0, 1))
+      );
+      ''',
+    );
+    await migrator.database.customStatement(
+      'CREATE INDEX IF NOT EXISTS idx_budgets_account_id ON budgets(account_id);',
+    );
+    await migrator.database.customStatement(
+      'CREATE INDEX IF NOT EXISTS idx_budgets_month ON budgets(month);',
+    );
+    await migrator.database.customStatement(
+      'CREATE INDEX IF NOT EXISTS idx_budget_alerts_budget_id ON budget_alerts(budget_id);',
+    );
+    await migrator.database.customStatement(
+      'CREATE INDEX IF NOT EXISTS idx_budget_alerts_triggered_at ON budget_alerts(triggered_at);',
+    );
+    await migrator.database.customStatement(
+      'PRAGMA user_version = 9;',
     );
   }
 }

--- a/lib/data/local_db/chobo_records.dart
+++ b/lib/data/local_db/chobo_records.dart
@@ -870,3 +870,132 @@ class ChoboCounterpartyRecord {
     );
   }
 }
+
+class ChoboBudgetRecord {
+  const ChoboBudgetRecord({
+    required this.budgetId,
+    required this.accountId,
+    required this.month,
+    required this.amount,
+    this.alertThresholdPercent = 80,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final String budgetId;
+  final String accountId;
+  final String month;
+  final int amount;
+  final int alertThresholdPercent;
+  final String createdAt;
+  final String updatedAt;
+
+  ChoboBudgetRecord copyWith({
+    String? budgetId,
+    String? accountId,
+    String? month,
+    int? amount,
+    int? alertThresholdPercent,
+    String? createdAt,
+    String? updatedAt,
+  }) {
+    return ChoboBudgetRecord(
+      budgetId: budgetId ?? this.budgetId,
+      accountId: accountId ?? this.accountId,
+      month: month ?? this.month,
+      amount: amount ?? this.amount,
+      alertThresholdPercent:
+          alertThresholdPercent ?? this.alertThresholdPercent,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+
+  Map<String, Object?> toDatabaseJson() {
+    return <String, Object?>{
+      'budget_id': budgetId,
+      'account_id': accountId,
+      'month': month,
+      'amount': amount,
+      'alert_threshold_percent': alertThresholdPercent,
+      'created_at': createdAt,
+      'updated_at': updatedAt,
+    };
+  }
+
+  static ChoboBudgetRecord fromRow(QueryRow row) {
+    return ChoboBudgetRecord(
+      budgetId: row.read<String>('budget_id'),
+      accountId: row.read<String>('account_id'),
+      month: row.read<String>('month'),
+      amount: row.read<int>('amount'),
+      alertThresholdPercent: row.read<int>('alert_threshold_percent'),
+      createdAt: row.read<String>('created_at'),
+      updatedAt: row.read<String>('updated_at'),
+    );
+  }
+}
+
+class ChoboBudgetAlertRecord {
+  const ChoboBudgetAlertRecord({
+    required this.alertId,
+    required this.budgetId,
+    required this.triggeredAt,
+    required this.actualAmount,
+    required this.budgetAmount,
+    required this.thresholdPercent,
+    this.notified = false,
+  });
+
+  final String alertId;
+  final String budgetId;
+  final String triggeredAt;
+  final int actualAmount;
+  final int budgetAmount;
+  final int thresholdPercent;
+  final bool notified;
+
+  ChoboBudgetAlertRecord copyWith({
+    String? alertId,
+    String? budgetId,
+    String? triggeredAt,
+    int? actualAmount,
+    int? budgetAmount,
+    int? thresholdPercent,
+    bool? notified,
+  }) {
+    return ChoboBudgetAlertRecord(
+      alertId: alertId ?? this.alertId,
+      budgetId: budgetId ?? this.budgetId,
+      triggeredAt: triggeredAt ?? this.triggeredAt,
+      actualAmount: actualAmount ?? this.actualAmount,
+      budgetAmount: budgetAmount ?? this.budgetAmount,
+      thresholdPercent: thresholdPercent ?? this.thresholdPercent,
+      notified: notified ?? this.notified,
+    );
+  }
+
+  Map<String, Object?> toDatabaseJson() {
+    return <String, Object?>{
+      'alert_id': alertId,
+      'budget_id': budgetId,
+      'triggered_at': triggeredAt,
+      'actual_amount': actualAmount,
+      'budget_amount': budgetAmount,
+      'threshold_percent': thresholdPercent,
+      'notified': notified ? 1 : 0,
+    };
+  }
+
+  static ChoboBudgetAlertRecord fromRow(QueryRow row) {
+    return ChoboBudgetAlertRecord(
+      alertId: row.read<String>('alert_id'),
+      budgetId: row.read<String>('budget_id'),
+      triggeredAt: row.read<String>('triggered_at'),
+      actualAmount: row.read<int>('actual_amount'),
+      budgetAmount: row.read<int>('budget_amount'),
+      thresholdPercent: row.read<int>('threshold_percent'),
+      notified: row.read<int>('notified') == 1,
+    );
+  }
+}

--- a/lib/data/local_db/chobo_schema.dart
+++ b/lib/data/local_db/chobo_schema.dart
@@ -1,7 +1,7 @@
 class ChoboSchema {
   ChoboSchema._();
 
-  static const int schemaVersion = 8;
+  static const int schemaVersion = 9;
 
   static const String databaseFileName = 'chobo.sqlite';
 
@@ -17,6 +17,8 @@ class ChoboSchema {
   static const String tagsTable = 'tags';
   static const String transactionTagsTable = 'transaction_tags';
   static const String counterpartiesTable = 'counterparties';
+  static const String budgetsTable = 'budgets';
+  static const String budgetAlertsTable = 'budget_alerts';
 
   static const List<String> createStatements = <String>[
     _createAccountsTable,
@@ -31,6 +33,8 @@ class ChoboSchema {
     _createTagsTable,
     _createTransactionTagsTable,
     _createCounterpartiesTable,
+    _createBudgetsTable,
+    _createBudgetAlertsTable,
   ];
 
   static const List<String> createIndexStatements = <String>[
@@ -54,6 +58,10 @@ class ChoboSchema {
     'CREATE INDEX IF NOT EXISTS idx_transaction_tags_transaction_id ON transaction_tags(transaction_id);',
     'CREATE INDEX IF NOT EXISTS idx_transaction_tags_tag_id ON transaction_tags(tag_id);',
     'CREATE INDEX IF NOT EXISTS idx_counterparties_normalized_name ON counterparties(normalized_name);',
+    'CREATE INDEX IF NOT EXISTS idx_budgets_account_id ON budgets(account_id);',
+    'CREATE INDEX IF NOT EXISTS idx_budgets_month ON budgets(month);',
+    'CREATE INDEX IF NOT EXISTS idx_budget_alerts_budget_id ON budget_alerts(budget_id);',
+    'CREATE INDEX IF NOT EXISTS idx_budget_alerts_triggered_at ON budget_alerts(triggered_at);',
   ];
 
   static const List<String> createAllStatements = <String>[
@@ -206,6 +214,31 @@ CREATE TABLE IF NOT EXISTS counterparties (
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
   UNIQUE(normalized_name)
+);
+''';
+
+  static const String _createBudgetsTable = '''
+CREATE TABLE IF NOT EXISTS budgets (
+  budget_id TEXT PRIMARY KEY,
+  account_id TEXT NOT NULL REFERENCES accounts(account_id) ON UPDATE CASCADE ON DELETE CASCADE,
+  month TEXT NOT NULL,
+  amount INTEGER NOT NULL CHECK (amount >= 0),
+  alert_threshold_percent INTEGER NOT NULL DEFAULT 80 CHECK (alert_threshold_percent >= 0 AND alert_threshold_percent <= 100),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE(account_id, month)
+);
+''';
+
+  static const String _createBudgetAlertsTable = '''
+CREATE TABLE IF NOT EXISTS budget_alerts (
+  alert_id TEXT PRIMARY KEY,
+  budget_id TEXT NOT NULL REFERENCES budgets(budget_id) ON UPDATE CASCADE ON DELETE CASCADE,
+  triggered_at TEXT NOT NULL,
+  actual_amount INTEGER NOT NULL,
+  budget_amount INTEGER NOT NULL,
+  threshold_percent INTEGER NOT NULL,
+  notified INTEGER NOT NULL DEFAULT 0 CHECK (notified IN (0, 1))
 );
 ''';
 }

--- a/lib/data/repository/budget_alert_repository.dart
+++ b/lib/data/repository/budget_alert_repository.dart
@@ -1,0 +1,132 @@
+import 'package:drift/drift.dart';
+
+import '../local_db/app_database.dart';
+import '../local_db/chobo_records.dart';
+
+class BudgetAlertRepository {
+  BudgetAlertRepository(this._db);
+
+  final AppDatabase _db;
+
+  Future<void> createAlert(ChoboBudgetAlertRecord alert) async {
+    await _db.customInsert(
+      '''
+      INSERT INTO budget_alerts (
+        alert_id,
+        budget_id,
+        triggered_at,
+        actual_amount,
+        budget_amount,
+        threshold_percent,
+        notified
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      ''',
+      variables: <Variable>[
+        Variable(alert.alertId),
+        Variable(alert.budgetId),
+        Variable(alert.triggeredAt),
+        Variable(alert.actualAmount),
+        Variable(alert.budgetAmount),
+        Variable(alert.thresholdPercent),
+        Variable(alert.notified ? 1 : 0),
+      ],
+    );
+  }
+
+  Future<List<ChoboBudgetAlertRecord>> listAlertsForBudget(
+    String budgetId, {
+    int limit = 10,
+  }) async {
+    final rows = await _db.customSelect(
+      '''
+      SELECT alert_id, budget_id, triggered_at, actual_amount,
+             budget_amount, threshold_percent, notified
+      FROM budget_alerts
+      WHERE budget_id = ?
+      ORDER BY triggered_at DESC
+      LIMIT ?
+      ''',
+      variables: <Variable>[
+        Variable(budgetId),
+        Variable(limit),
+      ],
+    ).get();
+    return rows.map(ChoboBudgetAlertRecord.fromRow).toList(growable: false);
+  }
+
+  Future<List<ChoboBudgetAlertRecord>> listRecentAlerts({
+    int limit = 20,
+  }) async {
+    final rows = await _db.customSelect(
+      '''
+      SELECT alert_id, budget_id, triggered_at, actual_amount,
+             budget_amount, threshold_percent, notified
+      FROM budget_alerts
+      ORDER BY triggered_at DESC
+      LIMIT ?
+      ''',
+      variables: <Variable>[Variable(limit)],
+    ).get();
+    return rows.map(ChoboBudgetAlertRecord.fromRow).toList(growable: false);
+  }
+
+  Future<List<ChoboBudgetAlertRecord>> listUnnotifiedAlerts() async {
+    final rows = await _db.customSelect(
+      '''
+      SELECT alert_id, budget_id, triggered_at, actual_amount,
+             budget_amount, threshold_percent, notified
+      FROM budget_alerts
+      WHERE notified = 0
+      ORDER BY triggered_at DESC
+      ''',
+    ).get();
+    return rows.map(ChoboBudgetAlertRecord.fromRow).toList(growable: false);
+  }
+
+  Future<int> markAsNotified(String alertId) async {
+    return _db.customUpdate(
+      'UPDATE budget_alerts SET notified = 1 WHERE alert_id = ?',
+      variables: <Variable>[Variable(alertId)],
+    );
+  }
+
+  Future<int> markAllAsNotified(List<String> alertIds) async {
+    if (alertIds.isEmpty) return 0;
+
+    final placeholders = alertIds.map((_) => '?').join(',');
+    return _db.customUpdate(
+      'UPDATE budget_alerts SET notified = 1 WHERE alert_id IN ($placeholders)',
+      variables: alertIds.map((id) => Variable(id)).toList(),
+    );
+  }
+
+  Future<bool> hasRecentAlertForBudget(String budgetId, String since) async {
+    final row = await _db.customSelect(
+      '''
+      SELECT 1 AS has_alert
+      FROM budget_alerts
+      WHERE budget_id = ? AND triggered_at >= ?
+      LIMIT 1
+      ''',
+      variables: <Variable>[
+        Variable(budgetId),
+        Variable(since),
+      ],
+    ).getSingleOrNull();
+    return row != null;
+  }
+
+  Future<int> deleteAlert(String alertId) {
+    return _db.customUpdate(
+      'DELETE FROM budget_alerts WHERE alert_id = ?',
+      variables: <Variable>[Variable(alertId)],
+    );
+  }
+
+  Future<int> deleteAlertsForBudget(String budgetId) {
+    return _db.customUpdate(
+      'DELETE FROM budget_alerts WHERE budget_id = ?',
+      variables: <Variable>[Variable(budgetId)],
+    );
+  }
+}

--- a/lib/data/repository/budget_repository.dart
+++ b/lib/data/repository/budget_repository.dart
@@ -1,0 +1,172 @@
+import 'package:drift/drift.dart';
+
+import '../local_db/app_database.dart';
+import '../local_db/chobo_records.dart';
+
+class BudgetRepository {
+  BudgetRepository(this._db);
+
+  final AppDatabase _db;
+
+  Future<void> createBudget(ChoboBudgetRecord budget) async {
+    await _db.customInsert(
+      '''
+      INSERT INTO budgets (
+        budget_id,
+        account_id,
+        month,
+        amount,
+        alert_threshold_percent,
+        created_at,
+        updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      ''',
+      variables: <Variable>[
+        Variable(budget.budgetId),
+        Variable(budget.accountId),
+        Variable(budget.month),
+        Variable(budget.amount),
+        Variable(budget.alertThresholdPercent),
+        Variable(budget.createdAt),
+        Variable(budget.updatedAt),
+      ],
+    );
+  }
+
+  Future<ChoboBudgetRecord?> getBudget(String budgetId) async {
+    final row = await _db.customSelect(
+      '''
+      SELECT budget_id, account_id, month, amount, alert_threshold_percent,
+             created_at, updated_at
+      FROM budgets
+      WHERE budget_id = ?
+      ''',
+      variables: <Variable>[Variable(budgetId)],
+    ).getSingleOrNull();
+    return row == null ? null : ChoboBudgetRecord.fromRow(row);
+  }
+
+  Future<ChoboBudgetRecord?> getBudgetByAccountAndMonth(
+    String accountId,
+    String month,
+  ) async {
+    final row = await _db.customSelect(
+      '''
+      SELECT budget_id, account_id, month, amount, alert_threshold_percent,
+             created_at, updated_at
+      FROM budgets
+      WHERE account_id = ? AND month = ?
+      ''',
+      variables: <Variable>[
+        Variable(accountId),
+        Variable(month),
+      ],
+    ).getSingleOrNull();
+    return row == null ? null : ChoboBudgetRecord.fromRow(row);
+  }
+
+  Future<List<ChoboBudgetRecord>> listBudgetsForMonth(String month) async {
+    final rows = await _db.customSelect(
+      '''
+      SELECT budget_id, account_id, month, amount, alert_threshold_percent,
+             created_at, updated_at
+      FROM budgets
+      WHERE month = ?
+      ORDER BY account_id
+      ''',
+      variables: <Variable>[Variable(month)],
+    ).get();
+    return rows.map(ChoboBudgetRecord.fromRow).toList(growable: false);
+  }
+
+  Future<List<ChoboBudgetRecord>> listBudgetsForAccount(
+    String accountId,
+  ) async {
+    final rows = await _db.customSelect(
+      '''
+      SELECT budget_id, account_id, month, amount, alert_threshold_percent,
+             created_at, updated_at
+      FROM budgets
+      WHERE account_id = ?
+      ORDER BY month DESC
+      ''',
+      variables: <Variable>[Variable(accountId)],
+    ).get();
+    return rows.map(ChoboBudgetRecord.fromRow).toList(growable: false);
+  }
+
+  Future<int> updateBudget(ChoboBudgetRecord budget,
+      {String? expectedUpdatedAt}) async {
+    if (expectedUpdatedAt != null) {
+      return _db.customUpdate(
+        '''
+        UPDATE budgets
+        SET amount = ?,
+            alert_threshold_percent = ?,
+            updated_at = ?
+        WHERE budget_id = ? AND updated_at = ?
+        ''',
+        variables: <Variable>[
+          Variable(budget.amount),
+          Variable(budget.alertThresholdPercent),
+          Variable(budget.updatedAt),
+          Variable(budget.budgetId),
+          Variable(expectedUpdatedAt),
+        ],
+      );
+    }
+    return _db.customUpdate(
+      '''
+      UPDATE budgets
+      SET amount = ?,
+          alert_threshold_percent = ?,
+          updated_at = ?
+      WHERE budget_id = ?
+      ''',
+      variables: <Variable>[
+        Variable(budget.amount),
+        Variable(budget.alertThresholdPercent),
+        Variable(budget.updatedAt),
+        Variable(budget.budgetId),
+      ],
+    );
+  }
+
+  Future<int> deleteBudget(String budgetId) {
+    return _db.customUpdate(
+      'DELETE FROM budgets WHERE budget_id = ?',
+      variables: <Variable>[Variable(budgetId)],
+    );
+  }
+
+  Future<void> upsertBudget(ChoboBudgetRecord budget) async {
+    final existing = await getBudgetByAccountAndMonth(
+      budget.accountId,
+      budget.month,
+    );
+    if (existing != null) {
+      final updated = await updateBudget(
+        budget.copyWith(
+          budgetId: existing.budgetId,
+          createdAt: existing.createdAt,
+        ),
+        expectedUpdatedAt: existing.updatedAt,
+      );
+      if (updated == 0) {
+        throw ConcurrencyException(
+          'Budget was modified by another process. Please retry.',
+        );
+      }
+    } else {
+      await createBudget(budget);
+    }
+  }
+}
+
+class ConcurrencyException implements Exception {
+  const ConcurrencyException(this.message);
+  final String message;
+
+  @override
+  String toString() => 'ConcurrencyException: $message';
+}

--- a/lib/data/service/budget_alert_service.dart
+++ b/lib/data/service/budget_alert_service.dart
@@ -1,0 +1,165 @@
+import '../local_db/chobo_records.dart';
+import '../repository/budget_alert_repository.dart';
+import '../repository/budget_repository.dart';
+import 'budget_service.dart';
+import 'notification_service.dart';
+
+class BudgetAlertService {
+  BudgetAlertService(
+    this._budgetAlertRepository,
+    this._budgetRepository,
+    this._budgetService,
+    this._notificationService,
+  );
+
+  final BudgetAlertRepository _budgetAlertRepository;
+  final BudgetRepository _budgetRepository;
+  final BudgetService _budgetService;
+  final NotificationService _notificationService;
+
+  static const _alertCooldownHours = 24;
+
+  Future<List<BudgetAlertDto>> checkBudgetAlerts(String month) async {
+    final triggeredAlerts = <BudgetAlertDto>[];
+    final budgets = await _budgetRepository.listBudgetsForMonth(month);
+
+    for (final budget in budgets) {
+      final comparison = await _budgetService.getBudgetComparison(
+        budget.budgetId,
+        month,
+      );
+
+      if (comparison == null) continue;
+
+      if (comparison.isOverBudget) {
+        final shouldTrigger = await _shouldTriggerAlert(budget.budgetId);
+        if (shouldTrigger) {
+          final alert = await _createAlert(
+            budget,
+            comparison.actualAmount,
+            isThreshold: false,
+          );
+          triggeredAlerts.add(alert);
+        }
+      } else if (comparison.isNearLimit) {
+        final shouldTrigger = await _shouldTriggerAlert(budget.budgetId);
+        if (shouldTrigger) {
+          final alert = await _createAlert(
+            budget,
+            comparison.actualAmount,
+            isThreshold: true,
+          );
+          triggeredAlerts.add(alert);
+        }
+      }
+    }
+
+    return triggeredAlerts;
+  }
+
+  Future<List<BudgetAlertDto>> checkAndNotifyAlerts(String month) async {
+    final triggeredAlerts = await checkBudgetAlerts(month);
+
+    for (final alert in triggeredAlerts) {
+      await _notificationService.showBudgetAlert(alert);
+    }
+
+    return triggeredAlerts;
+  }
+
+  Future<bool> _shouldTriggerAlert(String budgetId) async {
+    final cooldownStart = DateTime.now()
+        .subtract(const Duration(hours: _alertCooldownHours))
+        .toUtc()
+        .toIso8601String();
+
+    return !(await _budgetAlertRepository.hasRecentAlertForBudget(
+      budgetId,
+      cooldownStart,
+    ));
+  }
+
+  Future<BudgetAlertDto> _createAlert(
+    ChoboBudgetRecord budget,
+    int actualAmount, {
+    required bool isThreshold,
+  }) async {
+    final alertRecord = ChoboBudgetAlertRecord(
+      alertId: _generateId(),
+      budgetId: budget.budgetId,
+      triggeredAt: DateTime.now().toUtc().toIso8601String(),
+      actualAmount: actualAmount,
+      budgetAmount: budget.amount,
+      thresholdPercent: budget.alertThresholdPercent,
+      notified: false,
+    );
+
+    await _budgetAlertRepository.createAlert(alertRecord);
+
+    return BudgetAlertDto(
+      alertId: alertRecord.alertId,
+      budgetId: budget.budgetId,
+      accountId: budget.accountId,
+      month: budget.month,
+      actualAmount: actualAmount,
+      budgetAmount: budget.amount,
+      thresholdPercent: budget.alertThresholdPercent,
+      percentUsed:
+          budget.amount > 0 ? (actualAmount * 100 / budget.amount).round() : 0,
+      triggeredAt: alertRecord.triggeredAt,
+      isThreshold: isThreshold,
+    );
+  }
+
+  Future<List<ChoboBudgetAlertRecord>> getRecentAlerts({
+    int limit = 20,
+  }) {
+    return _budgetAlertRepository.listRecentAlerts(limit: limit);
+  }
+
+  Future<List<ChoboBudgetAlertRecord>> getAlertsForBudget(
+    String budgetId, {
+    int limit = 10,
+  }) {
+    return _budgetAlertRepository.listAlertsForBudget(
+      budgetId,
+      limit: limit,
+    );
+  }
+
+  Future<void> dismissAlert(String alertId) async {
+    await _budgetAlertRepository.markAsNotified(alertId);
+  }
+
+  String _generateId() {
+    return 'alert_${DateTime.now().millisecondsSinceEpoch}';
+  }
+}
+
+class BudgetAlertDto {
+  const BudgetAlertDto({
+    required this.alertId,
+    required this.budgetId,
+    required this.accountId,
+    required this.month,
+    required this.actualAmount,
+    required this.budgetAmount,
+    required this.thresholdPercent,
+    required this.percentUsed,
+    required this.triggeredAt,
+    required this.isThreshold,
+  });
+
+  final String alertId;
+  final String budgetId;
+  final String accountId;
+  final String month;
+  final int actualAmount;
+  final int budgetAmount;
+  final int thresholdPercent;
+  final int percentUsed;
+  final String triggeredAt;
+  final bool isThreshold;
+
+  int get overspentAmount => actualAmount - budgetAmount;
+}

--- a/lib/data/service/budget_service.dart
+++ b/lib/data/service/budget_service.dart
@@ -1,0 +1,228 @@
+import 'package:drift/drift.dart';
+
+import '../local_db/app_database.dart';
+import '../local_db/chobo_records.dart';
+import '../repository/account_repository.dart';
+import '../repository/budget_repository.dart';
+
+class BudgetService {
+  BudgetService(
+    this._budgetRepository,
+    this._accountRepository,
+    this._db,
+  );
+
+  final BudgetRepository _budgetRepository;
+  final AccountRepository _accountRepository;
+  final AppDatabase _db;
+
+  Future<MonthlyBudgetDto> getMonthlyBudget(String month) async {
+    final budgets = await _budgetRepository.listBudgetsForMonth(month);
+    final actualSpending = await _getActualSpendingByAccount(month);
+    final totalBudget = budgets.fold<int>(0, (sum, b) => sum + b.amount);
+    final totalActual = budgets.fold<int>(
+      0,
+      (sum, b) => sum + (actualSpending[b.accountId] ?? 0),
+    );
+
+    return MonthlyBudgetDto(
+      month: month,
+      totalBudget: totalBudget,
+      totalActual: totalActual,
+      totalRemaining: totalBudget - totalActual,
+      categories: await _buildCategoryComparisons(budgets, actualSpending),
+    );
+  }
+
+  Future<List<BudgetComparisonDto>> getBudgetComparisons(String month) async {
+    final budgets = await _budgetRepository.listBudgetsForMonth(month);
+    final actualSpending = await _getActualSpendingByAccount(month);
+    return _buildCategoryComparisons(budgets, actualSpending);
+  }
+
+  Future<BudgetComparisonDto?> getBudgetComparison(
+    String budgetId,
+    String month,
+  ) async {
+    final budget = await _budgetRepository.getBudget(budgetId);
+    if (budget == null) return null;
+    final actualSpending = await _getActualSpendingByAccount(month);
+    final actual = actualSpending[budget.accountId] ?? 0;
+    return _buildComparison(budget, actual);
+  }
+
+  Future<List<BudgetComparisonDto>> _buildCategoryComparisons(
+    List<ChoboBudgetRecord> budgets,
+    Map<String, int> actualSpending,
+  ) async {
+    final accounts = await _accountRepository.listAccounts();
+    final accountMap = {for (final a in accounts) a.accountId: a};
+
+    final comparisons = <BudgetComparisonDto>[];
+    for (final budget in budgets) {
+      final actual = actualSpending[budget.accountId] ?? 0;
+      final account = accountMap[budget.accountId];
+      comparisons.add(_buildComparison(budget, actual, account?.name));
+    }
+    return comparisons;
+  }
+
+  BudgetComparisonDto _buildComparison(
+    ChoboBudgetRecord budget,
+    int actual, [
+    String? accountName,
+  ]) {
+    final percentUsed =
+        budget.amount > 0 ? (actual * 100 / budget.amount).round() : 0;
+    final isOverBudget = actual > budget.amount;
+    final isNearLimit = !isOverBudget &&
+        budget.amount > 0 &&
+        percentUsed >= budget.alertThresholdPercent;
+
+    return BudgetComparisonDto(
+      budgetId: budget.budgetId,
+      accountId: budget.accountId,
+      accountName: accountName ?? budget.accountId,
+      month: budget.month,
+      budgetAmount: budget.amount,
+      actualAmount: actual,
+      remaining: budget.amount - actual,
+      percentUsed: percentUsed,
+      alertThreshold: budget.alertThresholdPercent,
+      isOverBudget: isOverBudget,
+      isNearLimit: isNearLimit,
+    );
+  }
+
+  Future<Map<String, int>> _getActualSpendingByAccount(String month) async {
+    final bounds = _MonthBounds.fromYearMonth(month);
+    final rows = await _db.customSelect(
+      '''
+      SELECT e.account_id AS account_id,
+             e.amount AS amount
+      FROM entries e
+      JOIN transactions t ON t.transaction_id = e.transaction_id
+      JOIN accounts a ON a.account_id = e.account_id
+      WHERE t.status = 'posted'
+        AND t.date >= ?
+        AND t.date < ?
+        AND a.kind = 'expense'
+      ORDER BY t.date, t.transaction_id, e.entry_id
+      ''',
+      variables: <Variable>[
+        Variable(bounds.start),
+        Variable(bounds.nextMonthStart),
+      ],
+    ).get();
+
+    final result = <String, int>{};
+    for (final row in rows) {
+      final accountId = row.read<String>('account_id');
+      final amount = row.read<int>('amount');
+      result[accountId] = (result[accountId] ?? 0) + amount;
+    }
+    return result;
+  }
+
+  Future<void> createBudget(ChoboBudgetRecord budget) {
+    return _budgetRepository.createBudget(budget);
+  }
+
+  Future<void> updateBudget(ChoboBudgetRecord budget) {
+    return _budgetRepository.updateBudget(budget);
+  }
+
+  Future<void> upsertBudget(ChoboBudgetRecord budget) {
+    return _budgetRepository.upsertBudget(budget);
+  }
+
+  Future<void> deleteBudget(String budgetId) {
+    return _budgetRepository.deleteBudget(budgetId);
+  }
+
+  Future<List<ChoboBudgetRecord>> listBudgetsForMonth(String month) {
+    return _budgetRepository.listBudgetsForMonth(month);
+  }
+}
+
+class MonthlyBudgetDto {
+  const MonthlyBudgetDto({
+    required this.month,
+    required this.totalBudget,
+    required this.totalActual,
+    required this.totalRemaining,
+    required this.categories,
+  });
+
+  final String month;
+  final int totalBudget;
+  final int totalActual;
+  final int totalRemaining;
+  final List<BudgetComparisonDto> categories;
+
+  int get percentUsed =>
+      totalBudget > 0 ? (totalActual * 100 / totalBudget).round() : 0;
+  bool get isOverBudget => totalActual > totalBudget;
+}
+
+class BudgetComparisonDto {
+  const BudgetComparisonDto({
+    required this.budgetId,
+    required this.accountId,
+    required this.accountName,
+    required this.month,
+    required this.budgetAmount,
+    required this.actualAmount,
+    required this.remaining,
+    required this.percentUsed,
+    required this.alertThreshold,
+    required this.isOverBudget,
+    required this.isNearLimit,
+  });
+
+  final String budgetId;
+  final String accountId;
+  final String accountName;
+  final String month;
+  final int budgetAmount;
+  final int actualAmount;
+  final int remaining;
+  final int percentUsed;
+  final int alertThreshold;
+  final bool isOverBudget;
+  final bool isNearLimit;
+}
+
+class _MonthBounds {
+  const _MonthBounds({
+    required this.month,
+    required this.start,
+    required this.end,
+    required this.nextMonthStart,
+    required this.previousDay,
+  });
+
+  final String month;
+  final String start;
+  final String end;
+  final String nextMonthStart;
+  final String previousDay;
+
+  factory _MonthBounds.fromYearMonth(String month) {
+    final monthStart = DateTime.parse('$month-01');
+    final nextMonthStart = DateTime(monthStart.year, monthStart.month + 1, 1);
+    final previousDay = monthStart.subtract(const Duration(days: 1));
+
+    return _MonthBounds(
+      month: month,
+      start: _dateOnly(monthStart),
+      end: _dateOnly(nextMonthStart.subtract(const Duration(days: 1))),
+      nextMonthStart: _dateOnly(nextMonthStart),
+      previousDay: _dateOnly(previousDay),
+    );
+  }
+
+  static String _dateOnly(DateTime dateTime) {
+    return dateTime.toIso8601String().substring(0, 10);
+  }
+}

--- a/lib/data/service/forecast_service.dart
+++ b/lib/data/service/forecast_service.dart
@@ -1,0 +1,419 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+
+import '../local_db/app_database.dart';
+import '../local_db/chobo_records.dart';
+import '../repository/recurring_template_repository.dart';
+
+class ForecastService {
+  ForecastService(
+    this._db,
+    this._recurringTemplateRepository,
+  );
+
+  final AppDatabase _db;
+  final RecurringTemplateRepository _recurringTemplateRepository;
+
+  Future<EndOfMonthForecastDto> getEndOfMonthForecast(String month) async {
+    final bounds = _MonthBounds.fromYearMonth(month);
+
+    final currentBalance = await _getCurrentAssetBalance();
+    final pendingPayments = await _getPendingTransactions(
+      bounds.start,
+      bounds.nextMonthStart,
+    );
+    final upcomingRecurring = await _getUpcomingRecurring(
+      bounds.nextMonthStart,
+    );
+
+    final totalPendingExpenses = pendingPayments
+        .where((p) => p.isExpense)
+        .fold<int>(0, (sum, p) => sum + p.amount);
+    final totalPendingIncome = pendingPayments
+        .where((p) => p.isIncome)
+        .fold<int>(0, (sum, p) => sum + p.amount);
+
+    final totalUpcomingExpenses = upcomingRecurring
+        .where((r) => r.isExpense)
+        .fold<int>(0, (sum, r) => sum + r.amount);
+    final totalUpcomingIncome = upcomingRecurring
+        .where((r) => r.isIncome)
+        .fold<int>(0, (sum, r) => sum + r.amount);
+
+    final predictedExpenses = totalPendingExpenses + totalUpcomingExpenses;
+    final predictedIncome = totalPendingIncome + totalUpcomingIncome;
+    final forecastBalance =
+        currentBalance + predictedIncome - predictedExpenses;
+
+    final dailyForecasts = await _getDailyForecasts(
+      month,
+      currentBalance,
+      pendingPayments,
+      upcomingRecurring,
+    );
+
+    return EndOfMonthForecastDto(
+      month: month,
+      currentBalance: currentBalance,
+      pendingExpenses: totalPendingExpenses,
+      pendingIncome: totalPendingIncome,
+      upcomingRecurringExpenses: totalUpcomingExpenses,
+      upcomingRecurringIncome: totalUpcomingIncome,
+      predictedExpenses: predictedExpenses,
+      predictedIncome: predictedIncome,
+      forecastBalance: forecastBalance,
+      pendingPayments: pendingPayments,
+      upcomingRecurring: upcomingRecurring,
+      dailyForecasts: dailyForecasts,
+    );
+  }
+
+  Future<int> _getCurrentAssetBalance() async {
+    final rows = await _db.customSelect(
+      '''
+      SELECT COALESCE(SUM(
+        CASE
+          WHEN e.direction = 'increase' THEN e.amount
+          ELSE -e.amount
+        END
+      ), 0) AS balance
+      FROM entries e
+      JOIN transactions t ON t.transaction_id = e.transaction_id
+      JOIN accounts a ON a.account_id = e.account_id
+      WHERE t.status = 'posted'
+        AND a.kind = 'asset'
+      ''',
+    ).getSingle();
+
+    return rows.read<int>('balance');
+  }
+
+  Future<List<PendingPaymentDto>> _getPendingTransactions(
+    String startDate,
+    String endDate,
+  ) async {
+    final rows = await _db.customSelect(
+      '''
+      SELECT t.transaction_id,
+             t.date,
+             t.type,
+             t.description,
+             e.amount,
+             a.name AS account_name
+      FROM transactions t
+      JOIN entries e ON e.transaction_id = t.transaction_id
+      JOIN accounts a ON a.account_id = e.account_id
+      WHERE t.status = 'pending'
+        AND t.date >= ?
+        AND t.date < ?
+        AND a.kind IN ('expense', 'income')
+      ORDER BY t.date, t.transaction_id
+      ''',
+      variables: <Variable>[
+        Variable(startDate),
+        Variable(endDate),
+      ],
+    ).get();
+
+    return rows.map((row) {
+      final type = row.read<String>('type');
+      final isExpense = ['expense', 'credit_expense'].contains(type);
+      final isIncome = type == 'income';
+      final desc = row.readNullable<String>('description');
+
+      return PendingPaymentDto(
+        transactionId: row.read<String>('transaction_id'),
+        date: row.read<String>('date'),
+        description: desc ?? '',
+        accountName: row.read<String>('account_name'),
+        amount: row.read<int>('amount'),
+        isExpense: isExpense,
+        isIncome: isIncome,
+      );
+    }).toList(growable: false);
+  }
+
+  Future<List<RecurringPaymentDto>> _getUpcomingRecurring(
+    String upToDate,
+  ) async {
+    final templates = await _recurringTemplateRepository.listTemplates(
+      activeOnly: true,
+    );
+
+    final upcoming = <RecurringPaymentDto>[];
+    final now = DateTime.now();
+
+    for (final template in templates) {
+      final occurrences = _generateOccurrences(
+        template,
+        now,
+        DateTime.parse(upToDate),
+      );
+
+      for (final date in occurrences) {
+        final entries = _parseEntriesTemplate(template.entriesTemplate);
+        final totalExpense = entries
+            .where((e) => e.isExpense)
+            .fold<int>(0, (sum, e) => sum + e.amount);
+        final totalIncome = entries
+            .where((e) => e.isIncome)
+            .fold<int>(0, (sum, e) => sum + e.amount);
+
+        upcoming.add(RecurringPaymentDto(
+          templateId: template.templateId,
+          name: template.name,
+          date: _dateOnly(date),
+          type: template.transactionType,
+          isExpense: totalExpense > 0,
+          isIncome: totalIncome > 0,
+          amount: totalExpense > 0 ? totalExpense : totalIncome,
+        ));
+      }
+    }
+
+    upcoming.sort((a, b) => a.date.compareTo(b.date));
+    return upcoming;
+  }
+
+  List<DateTime> _generateOccurrences(
+    ChoboRecurringTemplateRecord template,
+    DateTime from,
+    DateTime to,
+  ) {
+    final occurrences = <DateTime>[];
+    final startDate = DateTime.parse(template.startDate);
+
+    if (startDate.isAfter(to)) return occurrences;
+
+    var current = _nextOccurrence(
+        startDate, from, template.frequency, template.intervalValue);
+
+    while (!current.isAfter(to)) {
+      if (!current.isBefore(from)) {
+        occurrences.add(current);
+      }
+      current = _nextOccurrence(
+          current, from, template.frequency, template.intervalValue);
+    }
+
+    return occurrences;
+  }
+
+  DateTime _nextOccurrence(
+    DateTime last,
+    DateTime from,
+    String frequency,
+    int interval,
+  ) {
+    switch (frequency) {
+      case 'daily':
+        return last.add(Duration(days: interval));
+      case 'weekly':
+        return last.add(Duration(days: 7 * interval));
+      case 'monthly':
+        return DateTime(last.year, last.month + interval, last.day);
+      case 'yearly':
+        return DateTime(last.year + interval, last.month, last.day);
+      default:
+        return last.add(Duration(days: 30));
+    }
+  }
+
+  List<_EntryTemplateItem> _parseEntriesTemplate(String template) {
+    try {
+      final List<dynamic> entries = json.decode(template);
+      return entries.map((e) {
+        return _EntryTemplateItem(
+          accountId: e['account_id'] as String,
+          direction: e['direction'] as String,
+          amount: e['amount'] as int,
+        );
+      }).toList();
+    } catch (_) {
+      return [];
+    }
+  }
+
+  Future<List<DailyForecastDto>> _getDailyForecasts(
+    String month,
+    int startingBalance,
+    List<PendingPaymentDto> pendingPayments,
+    List<RecurringPaymentDto> upcomingRecurring,
+  ) async {
+    final forecasts = <DailyForecastDto>[];
+    final pendingByDate = <String, int>{};
+    final recurringByDate = <String, int>{};
+
+    for (final p in pendingPayments) {
+      pendingByDate[p.date] = (pendingByDate[p.date] ?? 0) + p.amount;
+    }
+
+    for (final r in upcomingRecurring) {
+      if (r.isExpense) {
+        recurringByDate[r.date] = (recurringByDate[r.date] ?? 0) + r.amount;
+      }
+    }
+
+    final bounds = _MonthBounds.fromYearMonth(month);
+    var currentDate = DateTime.now();
+    var runningBalance = startingBalance;
+
+    while (currentDate.isBefore(DateTime.parse(bounds.nextMonthStart))) {
+      final dateStr = _dateOnly(currentDate);
+      final pending = pendingByDate[dateStr] ?? 0;
+      final recurring = recurringByDate[dateStr] ?? 0;
+      final totalDeduction = pending + recurring;
+
+      runningBalance -= totalDeduction;
+
+      forecasts.add(DailyForecastDto(
+        date: dateStr,
+        predictedBalance: runningBalance,
+        pendingAmount: pending,
+        recurringAmount: recurring,
+      ));
+
+      currentDate = currentDate.add(const Duration(days: 1));
+    }
+
+    return forecasts;
+  }
+
+  String _dateOnly(DateTime dateTime) {
+    return dateTime.toIso8601String().substring(0, 10);
+  }
+}
+
+class EndOfMonthForecastDto {
+  const EndOfMonthForecastDto({
+    required this.month,
+    required this.currentBalance,
+    required this.pendingExpenses,
+    required this.pendingIncome,
+    required this.upcomingRecurringExpenses,
+    required this.upcomingRecurringIncome,
+    required this.predictedExpenses,
+    required this.predictedIncome,
+    required this.forecastBalance,
+    required this.pendingPayments,
+    required this.upcomingRecurring,
+    required this.dailyForecasts,
+  });
+
+  final String month;
+  final int currentBalance;
+  final int pendingExpenses;
+  final int pendingIncome;
+  final int upcomingRecurringExpenses;
+  final int upcomingRecurringIncome;
+  final int predictedExpenses;
+  final int predictedIncome;
+  final int forecastBalance;
+  final List<PendingPaymentDto> pendingPayments;
+  final List<RecurringPaymentDto> upcomingRecurring;
+  final List<DailyForecastDto> dailyForecasts;
+}
+
+class PendingPaymentDto {
+  const PendingPaymentDto({
+    required this.transactionId,
+    required this.date,
+    required this.description,
+    required this.accountName,
+    required this.amount,
+    required this.isExpense,
+    required this.isIncome,
+  });
+
+  final String transactionId;
+  final String date;
+  final String description;
+  final String accountName;
+  final int amount;
+  final bool isExpense;
+  final bool isIncome;
+}
+
+class RecurringPaymentDto {
+  const RecurringPaymentDto({
+    required this.templateId,
+    required this.name,
+    required this.date,
+    required this.type,
+    required this.isExpense,
+    required this.isIncome,
+    required this.amount,
+  });
+
+  final String templateId;
+  final String name;
+  final String date;
+  final String type;
+  final bool isExpense;
+  final bool isIncome;
+  final int amount;
+}
+
+class DailyForecastDto {
+  const DailyForecastDto({
+    required this.date,
+    required this.predictedBalance,
+    required this.pendingAmount,
+    required this.recurringAmount,
+  });
+
+  final String date;
+  final int predictedBalance;
+  final int pendingAmount;
+  final int recurringAmount;
+}
+
+class _EntryTemplateItem {
+  const _EntryTemplateItem({
+    required this.accountId,
+    required this.direction,
+    required this.amount,
+  });
+
+  final String accountId;
+  final String direction;
+  final int amount;
+
+  bool get isExpense => direction == 'decrease';
+  bool get isIncome => direction == 'increase';
+}
+
+class _MonthBounds {
+  const _MonthBounds({
+    required this.month,
+    required this.start,
+    required this.end,
+    required this.nextMonthStart,
+    required this.previousDay,
+  });
+
+  final String month;
+  final String start;
+  final String end;
+  final String nextMonthStart;
+  final String previousDay;
+
+  factory _MonthBounds.fromYearMonth(String month) {
+    final monthStart = DateTime.parse('$month-01');
+    final nextMonthStart = DateTime(monthStart.year, monthStart.month + 1, 1);
+    final previousDay = monthStart.subtract(const Duration(days: 1));
+
+    return _MonthBounds(
+      month: month,
+      start: _dateOnly(monthStart),
+      end: _dateOnly(nextMonthStart.subtract(const Duration(days: 1))),
+      nextMonthStart: _dateOnly(nextMonthStart),
+      previousDay: _dateOnly(previousDay),
+    );
+  }
+
+  static String _dateOnly(DateTime dateTime) {
+    return dateTime.toIso8601String().substring(0, 10);
+  }
+}

--- a/lib/data/service/notification_service.dart
+++ b/lib/data/service/notification_service.dart
@@ -1,0 +1,159 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:timezone/timezone.dart' as tz;
+import 'package:timezone/data/latest.dart' as tz;
+
+import 'budget_alert_service.dart';
+
+class NotificationService {
+  NotificationService() {
+    _initialize();
+  }
+
+  final FlutterLocalNotificationsPlugin _notifications =
+      FlutterLocalNotificationsPlugin();
+
+  bool _isInitialized = false;
+
+  void _initialize() {
+    if (_isInitialized) return;
+
+    tz.initializeTimeZones();
+
+    const androidSettings =
+        AndroidInitializationSettings('@mipmap/ic_launcher');
+    const iosSettings = DarwinInitializationSettings(
+      requestAlertPermission: true,
+      requestBadgePermission: true,
+      requestSoundPermission: true,
+    );
+
+    const initSettings = InitializationSettings(
+      android: androidSettings,
+      iOS: iosSettings,
+    );
+
+    _notifications.initialize(
+      initSettings,
+      onDidReceiveNotificationResponse: _onNotificationTapped,
+    );
+
+    _isInitialized = true;
+  }
+
+  void _onNotificationTapped(NotificationResponse response) {
+    final payload = response.payload;
+    if (payload != null && payload.isNotEmpty) {
+      debugPrint('Notification tapped with payload: $payload');
+    }
+  }
+
+  Future<bool> requestPermissions() async {
+    if (Platform.isIOS) {
+      final result = await _notifications
+          .resolvePlatformSpecificImplementation<
+              IOSFlutterLocalNotificationsPlugin>()
+          ?.requestPermissions(
+            alert: true,
+            badge: true,
+            sound: true,
+          );
+      return result ?? false;
+    } else if (Platform.isAndroid) {
+      final androidPlugin =
+          _notifications.resolvePlatformSpecificImplementation<
+              AndroidFlutterLocalNotificationsPlugin>();
+      final result = await androidPlugin?.requestNotificationsPermission();
+      return result ?? false;
+    }
+    return false;
+  }
+
+  Future<void> showBudgetAlert(BudgetAlertDto alert) async {
+    const androidDetails = AndroidNotificationDetails(
+      'budget_alerts',
+      'Budget Alerts',
+      channelDescription: 'Notifications for budget alerts',
+      importance: Importance.high,
+      priority: Priority.high,
+      showWhen: true,
+    );
+
+    const iosDetails = DarwinNotificationDetails(
+      presentAlert: true,
+      presentBadge: true,
+      presentSound: true,
+    );
+
+    const details = NotificationDetails(
+      android: androidDetails,
+      iOS: iosDetails,
+    );
+
+    final overspent = alert.overspentAmount;
+    final body = overspent > 0
+        ? '¥$overspent over budget for ${alert.month}'
+        : 'Budget threshold reached for ${alert.month}';
+
+    await _notifications.show(
+      alert.alertId.hashCode,
+      'Budget Alert',
+      body,
+      details,
+      payload: 'budget_alert:${alert.budgetId}',
+    );
+  }
+
+  Future<void> scheduleBudgetCheck({
+    required String month,
+    required DateTime scheduledTime,
+  }) async {
+    const androidDetails = AndroidNotificationDetails(
+      'budget_reminders',
+      'Budget Reminders',
+      channelDescription: 'Daily budget status reminders',
+      importance: Importance.defaultImportance,
+      priority: Priority.defaultPriority,
+    );
+
+    const iosDetails = DarwinNotificationDetails(
+      presentAlert: true,
+      presentBadge: true,
+      presentSound: false,
+    );
+
+    const details = NotificationDetails(
+      android: androidDetails,
+      iOS: iosDetails,
+    );
+
+    final scheduledDate = tz.TZDateTime.from(scheduledTime, tz.local);
+
+    await _notifications.zonedSchedule(
+      'budget_check_$month'.hashCode,
+      'Budget Check',
+      'Time to review your spending for $month',
+      scheduledDate,
+      details,
+      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+      matchDateTimeComponents: DateTimeComponents.time,
+      payload: 'budget_check:$month',
+    );
+  }
+
+  Future<void> cancelBudgetCheck(String month) async {
+    await _notifications.cancel('budget_check_$month'.hashCode);
+  }
+
+  Future<void> cancelAllNotifications() async {
+    await _notifications.cancelAll();
+  }
+
+  Future<List<PendingNotificationRequest>> getPendingNotifications() {
+    return _notifications.pendingNotificationRequests();
+  }
+}

--- a/lib/features/budget/budget_screen.dart
+++ b/lib/features/budget/budget_screen.dart
@@ -1,0 +1,311 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../app/chobo_providers.dart';
+import '../../data/repository/budget_repository.dart';
+import '../../data/service/budget_service.dart';
+import '../../data/service/forecast_service.dart';
+import 'widgets/budget_edit_dialog.dart';
+import 'widgets/budget_progress_card.dart';
+import 'widgets/forecast_card.dart';
+
+class BudgetScreen extends ConsumerWidget {
+  const BudgetScreen({
+    super.key,
+    required this.month,
+  });
+
+  final String month;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final budgetAsync = ref.watch(monthlyBudgetProvider(month));
+    final forecastAsync = ref.watch(endOfMonthForecastProvider(month));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_formatMonthLabel(month)),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.pop(),
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            tooltip: 'Add budget',
+            onPressed: () => _showAddBudgetDialog(context, ref),
+          ),
+        ],
+      ),
+      body: budgetAsync.when(
+        data: (budget) => _buildContent(context, ref, budget, forecastAsync),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, stackTrace) => Center(
+          child: Text('Budget load failed: $error'),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContent(
+    BuildContext context,
+    WidgetRef ref,
+    MonthlyBudgetDto budget,
+    AsyncValue<EndOfMonthForecastDto> forecastAsync,
+  ) {
+    return ListView(
+      padding: const EdgeInsets.only(bottom: 32),
+      children: [
+        _buildOverviewSection(context, budget),
+        const Divider(),
+        _buildForecastSection(context, forecastAsync),
+        const Divider(),
+        _buildBudgetCategoriesSection(context, ref, budget),
+      ],
+    );
+  }
+
+  Widget _buildOverviewSection(BuildContext context, MonthlyBudgetDto budget) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Overview',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              Expanded(
+                child: _StatCard(
+                  title: 'Budget',
+                  value: budget.totalBudget,
+                  color: Colors.blue,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: _StatCard(
+                  title: 'Spent',
+                  value: budget.totalActual,
+                  color: budget.isOverBudget ? Colors.red : Colors.orange,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: _StatCard(
+                  title: 'Remaining',
+                  value: budget.totalRemaining,
+                  color: budget.totalRemaining >= 0 ? Colors.green : Colors.red,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: _StatCard(
+                  title: 'Used',
+                  value: budget.percentUsed,
+                  suffix: '%',
+                  color: budget.percentUsed > 100
+                      ? Colors.red
+                      : budget.percentUsed > 80
+                          ? Colors.orange
+                          : Colors.green,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildForecastSection(
+    BuildContext context,
+    AsyncValue<EndOfMonthForecastDto> forecastAsync,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'End of Month Forecast',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 16),
+          forecastAsync.when(
+            data: (forecast) => ForecastCard(forecast: forecast),
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (error, stackTrace) => Center(
+              child: Text('Forecast load failed: $error'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBudgetCategoriesSection(
+    BuildContext context,
+    WidgetRef ref,
+    MonthlyBudgetDto budget,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'Categories',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              TextButton.icon(
+                onPressed: () => _showAddBudgetDialog(context, ref),
+                icon: const Icon(Icons.add, size: 18),
+                label: const Text('Add'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          if (budget.categories.isEmpty)
+            const Center(
+              child: Padding(
+                padding: EdgeInsets.all(32),
+                child: Text('No budgets set. Tap + to add one.'),
+              ),
+            )
+          else
+            ...budget.categories.map(
+              (comparison) => BudgetProgressCard(
+                comparison: comparison,
+                onTap: () => _showEditBudgetDialog(
+                  context,
+                  ref,
+                  comparison,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _showAddBudgetDialog(BuildContext context, WidgetRef ref) async {
+    final result = await showDialog<Map<String, dynamic>>(
+      context: context,
+      builder: (context) => BudgetEditDialog(month: month),
+    );
+
+    if (result != null) {
+      try {
+        final budgetRecord = result['record'];
+        await ref.read(budgetServiceProvider).upsertBudget(budgetRecord);
+        ref.invalidate(monthlyBudgetProvider(month));
+      } on ConcurrencyException catch (e) {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(e.message)),
+          );
+        }
+      }
+    }
+  }
+
+  Future<void> _showEditBudgetDialog(
+    BuildContext context,
+    WidgetRef ref,
+    BudgetComparisonDto comparison,
+  ) async {
+    final result = await showDialog<Map<String, dynamic>>(
+      context: context,
+      builder: (context) => BudgetEditDialog(
+        month: month,
+        initialAccountId: comparison.accountId,
+        initialAmount: comparison.budgetAmount,
+        initialThreshold: comparison.alertThreshold,
+      ),
+    );
+
+    if (result != null) {
+      try {
+        final budgetRecord = result['record'];
+        await ref.read(budgetServiceProvider).upsertBudget(budgetRecord);
+        ref.invalidate(monthlyBudgetProvider(month));
+      } on ConcurrencyException catch (e) {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(e.message)),
+          );
+        }
+      }
+    }
+  }
+
+  String _formatMonthLabel(String month) {
+    final parts = month.split('-');
+    if (parts.length != 2) return month;
+    return '${parts[0]}年${parts[1]}月 予算';
+  }
+}
+
+class _StatCard extends StatelessWidget {
+  const _StatCard({
+    required this.title,
+    required this.value,
+    this.suffix = '',
+    required this.color,
+  });
+
+  final String title;
+  final int value;
+  final String suffix;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Colors.grey[600],
+                  ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '¥${_formatAmount(value)}$suffix',
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                    color: color,
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _formatAmount(int amount) {
+    if (amount.abs() >= 10000) {
+      return '${(amount / 10000).round()}万';
+    }
+    return amount.toString().replaceAllMapped(
+          RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
+          (Match m) => '${m[1]},',
+        );
+  }
+}

--- a/lib/features/budget/widgets/budget_edit_dialog.dart
+++ b/lib/features/budget/widgets/budget_edit_dialog.dart
@@ -1,0 +1,216 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/chobo_providers.dart';
+import '../../../data/local_db/chobo_records.dart';
+
+class BudgetEditDialog extends ConsumerStatefulWidget {
+  const BudgetEditDialog({
+    super.key,
+    required this.month,
+    this.initialAccountId,
+    this.initialAmount,
+    this.initialThreshold,
+  });
+
+  final String month;
+  final String? initialAccountId;
+  final int? initialAmount;
+  final int? initialThreshold;
+
+  @override
+  ConsumerState<BudgetEditDialog> createState() => _BudgetEditDialogState();
+}
+
+class _BudgetEditDialogState extends ConsumerState<BudgetEditDialog> {
+  late final TextEditingController _amountController;
+  late final TextEditingController _thresholdController;
+  String? _selectedAccountId;
+  bool _isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _amountController = TextEditingController(
+      text: widget.initialAmount?.toString() ?? '',
+    );
+    _thresholdController = TextEditingController(
+      text: (widget.initialThreshold ?? 80).toString(),
+    );
+    _selectedAccountId = widget.initialAccountId;
+  }
+
+  @override
+  void dispose() {
+    _amountController.dispose();
+    _thresholdController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accountsAsync = ref.watch(accountsProvider);
+
+    return AlertDialog(
+      title:
+          Text(widget.initialAccountId == null ? 'Add Budget' : 'Edit Budget'),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Category'),
+            const SizedBox(height: 8),
+            accountsAsync.when(
+              data: (accounts) {
+                final expenseAccounts = accounts
+                    .where((a) => a.kind == 'expense' && !a.isArchived)
+                    .toList();
+                return DropdownButtonFormField<String>(
+                  initialValue: _selectedAccountId,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    hintText: 'Select category',
+                  ),
+                  items: expenseAccounts.map((account) {
+                    return DropdownMenuItem(
+                      value: account.accountId,
+                      child: Text(account.name),
+                    );
+                  }).toList(),
+                  onChanged: widget.initialAccountId != null
+                      ? null
+                      : (value) {
+                          setState(() {
+                            _selectedAccountId = value;
+                          });
+                        },
+                );
+              },
+              loading: () => const LinearProgressIndicator(),
+              error: (error, stackTrace) => Text('Error: $error'),
+            ),
+            const SizedBox(height: 16),
+            const Text('Budget Amount'),
+            const SizedBox(height: 8),
+            TextField(
+              controller: _amountController,
+              decoration: const InputDecoration(
+                border: OutlineInputBorder(),
+                prefixText: '¥ ',
+                hintText: '0',
+              ),
+              keyboardType: TextInputType.number,
+              inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            ),
+            const SizedBox(height: 16),
+            const Text('Alert Threshold'),
+            const SizedBox(height: 8),
+            TextField(
+              controller: _thresholdController,
+              decoration: const InputDecoration(
+                border: OutlineInputBorder(),
+                suffixText: '%',
+                hintText: '80',
+              ),
+              keyboardType: TextInputType.number,
+              inputFormatters: [
+                FilteringTextInputFormatter.digitsOnly,
+                LengthLimitingTextInputFormatter(3),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Alert when spending reaches this percentage of budget',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Colors.grey[600],
+                  ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _isLoading ? null : () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _isLoading ? null : _submit,
+          child: _isLoading
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('Save'),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _submit() async {
+    if (_selectedAccountId == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please select a category')),
+      );
+      return;
+    }
+
+    final amountText = _amountController.text.trim();
+    if (amountText.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please enter a budget amount')),
+      );
+      return;
+    }
+
+    final amount = int.tryParse(amountText) ?? 0;
+    if (amount < 0) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Budget amount must be positive')),
+      );
+      return;
+    }
+
+    final thresholdText = _thresholdController.text.trim();
+    final threshold = int.tryParse(thresholdText);
+    if (threshold == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+            content: Text('Please enter a valid number for threshold')),
+      );
+      return;
+    }
+    if (threshold < 0 || threshold > 100) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Threshold must be between 0 and 100')),
+      );
+      return;
+    }
+
+    setState(() => _isLoading = true);
+
+    final now = DateTime.now().toUtc().toIso8601String();
+
+    final existingBudget = await ref
+        .read(budgetRepositoryProvider)
+        .getBudgetByAccountAndMonth(_selectedAccountId!, widget.month);
+
+    final budgetRecord = ChoboBudgetRecord(
+      budgetId: existingBudget?.budgetId ??
+          'budget_${DateTime.now().millisecondsSinceEpoch}',
+      accountId: _selectedAccountId!,
+      month: widget.month,
+      amount: amount,
+      alertThresholdPercent: threshold,
+      createdAt: existingBudget?.createdAt ?? now,
+      updatedAt: now,
+    );
+
+    if (mounted) {
+      Navigator.pop(context, {'record': budgetRecord});
+    }
+  }
+}

--- a/lib/features/budget/widgets/budget_progress_card.dart
+++ b/lib/features/budget/widgets/budget_progress_card.dart
@@ -1,0 +1,193 @@
+import 'package:flutter/material.dart';
+
+import '../../../data/service/budget_service.dart';
+
+class BudgetProgressCard extends StatelessWidget {
+  const BudgetProgressCard({
+    super.key,
+    required this.comparison,
+    this.onTap,
+  });
+
+  final BudgetComparisonDto comparison;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Expanded(
+                    child: Text(
+                      comparison.accountName,
+                      style: Theme.of(context).textTheme.titleMedium,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  if (comparison.isOverBudget)
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 4,
+                      ),
+                      decoration: BoxDecoration(
+                        color: Colors.red[100],
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Text(
+                        'Over',
+                        style: TextStyle(
+                          color: Colors.red[700],
+                          fontSize: 12,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    )
+                  else if (comparison.isNearLimit)
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 4,
+                      ),
+                      decoration: BoxDecoration(
+                        color: Colors.orange[100],
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Text(
+                        'Near',
+                        style: TextStyle(
+                          color: Colors.orange[700],
+                          fontSize: 12,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(4),
+                child: LinearProgressIndicator(
+                  value: (comparison.percentUsed / 100).clamp(0.0, 1.0),
+                  minHeight: 8,
+                  backgroundColor: Colors.grey[200],
+                  valueColor: AlwaysStoppedAnimation<Color>(
+                    _getProgressColor(comparison),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 12),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Spent',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: Colors.grey[600],
+                            ),
+                      ),
+                      Text(
+                        '¥${_formatAmount(comparison.actualAmount)}',
+                        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                              fontWeight: FontWeight.bold,
+                              color:
+                                  comparison.isOverBudget ? Colors.red : null,
+                            ),
+                      ),
+                    ],
+                  ),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        'Budget',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: Colors.grey[600],
+                            ),
+                      ),
+                      Text(
+                        '¥${_formatAmount(comparison.budgetAmount)}',
+                        style: Theme.of(context).textTheme.bodyLarge,
+                      ),
+                    ],
+                  ),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        comparison.remaining >= 0 ? 'Left' : 'Over',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: Colors.grey[600],
+                            ),
+                      ),
+                      Text(
+                        '¥${_formatAmount(comparison.remaining.abs())}',
+                        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                              fontWeight: FontWeight.bold,
+                              color: comparison.remaining >= 0
+                                  ? Colors.green
+                                  : Colors.red,
+                            ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  Text(
+                    '${comparison.percentUsed}% used',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Colors.grey[600],
+                        ),
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    '(threshold: ${comparison.alertThreshold}%)',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Colors.grey[400],
+                          fontSize: 10,
+                        ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Color _getProgressColor(BudgetComparisonDto comparison) {
+    if (comparison.isOverBudget) return Colors.red;
+    if (comparison.percentUsed >= comparison.alertThreshold) {
+      return Colors.orange;
+    }
+    return Colors.green;
+  }
+
+  String _formatAmount(int amount) {
+    if (amount.abs() >= 10000) {
+      return '${(amount / 10000).round()}万';
+    }
+    return amount.toString().replaceAllMapped(
+          RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
+          (Match m) => '${m[1]},',
+        );
+  }
+}

--- a/lib/features/budget/widgets/forecast_card.dart
+++ b/lib/features/budget/widgets/forecast_card.dart
@@ -1,0 +1,235 @@
+import 'package:flutter/material.dart';
+
+import '../../../data/service/forecast_service.dart';
+
+class ForecastCard extends StatelessWidget {
+  const ForecastCard({
+    super.key,
+    required this.forecast,
+  });
+
+  final EndOfMonthForecastDto forecast;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Current Balance',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: Colors.grey[600],
+                          ),
+                    ),
+                    Text(
+                      '¥${_formatAmount(forecast.currentBalance)}',
+                      style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                    ),
+                  ],
+                ),
+                Icon(
+                  Icons.arrow_forward,
+                  color: Colors.grey[400],
+                ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Text(
+                      'Forecast Balance',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: Colors.grey[600],
+                          ),
+                    ),
+                    Text(
+                      '¥${_formatAmount(forecast.forecastBalance)}',
+                      style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                            fontWeight: FontWeight.bold,
+                            color: forecast.forecastBalance >= 0
+                                ? Colors.green
+                                : Colors.red,
+                          ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            const Divider(),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(
+                  child: _ForecastItem(
+                    label: 'Pending Expenses',
+                    amount: forecast.pendingExpenses,
+                    icon: Icons.pending_actions,
+                    color: Colors.red,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: _ForecastItem(
+                    label: 'Upcoming Recurring',
+                    amount: forecast.upcomingRecurringExpenses,
+                    icon: Icons.repeat,
+                    color: Colors.orange,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(
+                  child: _ForecastItem(
+                    label: 'Pending Income',
+                    amount: forecast.pendingIncome,
+                    icon: Icons.payments,
+                    color: Colors.green,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: _ForecastItem(
+                    label: 'Upcoming Income',
+                    amount: forecast.upcomingRecurringIncome,
+                    icon: Icons.repeat_on,
+                    color: Colors.blue,
+                  ),
+                ),
+              ],
+            ),
+            if (forecast.pendingPayments.isNotEmpty) ...[
+              const SizedBox(height: 16),
+              const Divider(),
+              const SizedBox(height: 8),
+              Text(
+                'Pending Payments (${forecast.pendingPayments.length})',
+                style: Theme.of(context).textTheme.titleSmall,
+              ),
+              const SizedBox(height: 8),
+              ...forecast.pendingPayments.take(5).map(
+                    (payment) => Padding(
+                      padding: const EdgeInsets.only(bottom: 4),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(
+                            payment.description.isEmpty
+                                ? payment.accountName
+                                : payment.description,
+                            style: Theme.of(context).textTheme.bodySmall,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          Text(
+                            '¥${_formatAmount(payment.amount)}',
+                            style:
+                                Theme.of(context).textTheme.bodySmall?.copyWith(
+                                      color: Colors.red,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+              if (forecast.pendingPayments.length > 5)
+                Text(
+                  '... and ${forecast.pendingPayments.length - 5} more',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Colors.grey[600],
+                        fontStyle: FontStyle.italic,
+                      ),
+                ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _formatAmount(int amount) {
+    if (amount.abs() >= 10000) {
+      return '${(amount / 10000).round()}万';
+    }
+    return amount.toString().replaceAllMapped(
+          RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
+          (Match m) => '${m[1]},',
+        );
+  }
+}
+
+class _ForecastItem extends StatelessWidget {
+  const _ForecastItem({
+    required this.label,
+    required this.amount,
+    required this.icon,
+    required this.color,
+  });
+
+  final String label;
+  final int amount;
+  final IconData icon;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(icon, size: 14, color: color),
+              const SizedBox(width: 4),
+              Expanded(
+                child: Text(
+                  label,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: color,
+                        fontSize: 10,
+                      ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '¥${_formatAmount(amount)}',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: color,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatAmount(int amount) {
+    if (amount.abs() >= 10000) {
+      return '${(amount / 10000).round()}万';
+    }
+    return amount.toString().replaceAllMapped(
+          RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
+          (Match m) => '${m[1]},',
+        );
+  }
+}

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -95,6 +95,14 @@ class _QuickActionsBar extends StatelessWidget {
           const SizedBox(width: 8),
           Expanded(
             child: _QuickActionButton(
+              icon: Icons.wallet,
+              label: '予算',
+              onTap: () => context.push('/budget/$month'),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: _QuickActionButton(
               icon: Icons.repeat,
               label: '定期',
               onTap: () => context.push('/recurring'),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,6 +113,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.12"
   drift:
     dependency: "direct main"
     description:
@@ -190,6 +198,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: ef41ae901e7529e52934feba19ed82827b11baa67336829564aeab3129460610
+      url: "https://pub.dev"
+    source: hosted
+    version: "18.0.1"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: "8f685642876742c941b29c32030f6f4f6dacd0e4eaecb3efbb187d6a3812ca01"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "6c5b83c86bf819cdb177a9247a3722067dd8cc6313827ce7c77a4b238a26fd52"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -560,6 +592,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   platform:
     dependency: transitive
     description:
@@ -757,6 +797,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.16"
+  timezone:
+    dependency: "direct main"
+    description:
+      name: timezone
+      sha256: "2236ec079a174ce07434e89fcd3fcda430025eb7692244139a9cf54fdcf1fc7d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
   typed_data:
     dependency: transitive
     description:
@@ -837,6 +885,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,8 @@ dependencies:
   sqlite3: ^3.2.0
   package_info_plus: ^8.0.0
   fl_chart: ^0.69.0
+  flutter_local_notifications: ^18.0.0
+  timezone: ^0.9.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

Implements the budget and forecast feature with three sub-features:

- **#41 Monthly budget model** - Set monthly budgets per expense category, track spending vs budget
- **#42 End-of-month forecast** - Predict end-of-month balance based on pending transactions and recurring templates
- **#43 Budget alert policy** - Trigger notifications when spending reaches threshold or exceeds budget

## Changes

### Database
- Added `budgets` table for category budgets per month
- Added `budget_alerts` table for alert history
- Schema version updated to v9

### Data Layer
- `BudgetRepository` - CRUD for budgets
- `BudgetAlertRepository` - CRUD for budget alerts
- `BudgetService` - Budget comparison calculations
- `ForecastService` - End-of-month prediction
- `BudgetAlertService` - Alert checking/triggering
- `NotificationService` - Push notifications via flutter_local_notifications

### UI
- Budget screen at `/budget/:month`
- Budget progress cards showing spent vs budget
- Forecast card showing predicted end-of-month balance
- Edit dialog for setting budget amounts and alert thresholds

### Integration
- Added "Budget" quick action on home screen
- Notification permissions requested on app startup

## Commits

1. `72cef29` feat(budget): add database schema for budgets and alerts (v9)
2. `8ef839f` feat(budget): add repositories and services
3. `98d693a` feat(budget): add budget screen UI
4. `767ba4f` feat(budget): add providers and routing
5. `e13292d` feat(budget): add budget quick action to home screen
6. `b5333d8` chore(deps): add notification packages
7. `41c67bf` feat(notifications): request permission on startup

## Testing

- `flutter analyze` passes with no errors
- Code review completed with 6 issues fixed