### PR TITLE
feat: add search and input assist features

### DIFF
--- a/lib/app/chobo_providers.dart
+++ b/lib/app/chobo_providers.dart
@@ -26,6 +26,12 @@ import '../data/repository/tag_repository.dart';
 import '../data/repository/transaction_repository.dart';
 import '../data/repository/budget_repository.dart';
 import '../data/repository/budget_alert_repository.dart';
+import '../data/repository/transaction_search_repository.dart';
+import '../data/repository/template_repository.dart';
+import '../data/repository/autocomplete_repository.dart';
+import '../data/service/transaction_search_service.dart';
+import '../data/service/template_service.dart';
+import '../data/service/suggestion_service.dart';
 import '../data/service/reconciliation_service.dart';
 import '../data/service/monthly_summary_service.dart';
 import '../data/service/points_calculation_service.dart';
@@ -273,4 +279,32 @@ final endOfMonthForecastProvider =
 final recentBudgetAlertsProvider =
     FutureProvider<List<ChoboBudgetAlertRecord>>((ref) async {
   return ref.watch(budgetAlertServiceProvider).getRecentAlerts();
+});
+
+final transactionSearchRepositoryProvider =
+    Provider<TransactionSearchRepository>((ref) {
+  return TransactionSearchRepository(ref.watch(appDatabaseProvider));
+});
+
+final templateRepositoryProvider = Provider<TemplateRepository>((ref) {
+  return TemplateRepository(ref.watch(appDatabaseProvider));
+});
+
+final autocompleteRepositoryProvider = Provider<AutocompleteRepository>((ref) {
+  return AutocompleteRepository(ref.watch(appDatabaseProvider));
+});
+
+final transactionSearchServiceProvider =
+    Provider<TransactionSearchService>((ref) {
+  return TransactionSearchService(
+    ref.watch(transactionSearchRepositoryProvider),
+  );
+});
+
+final templateServiceProvider = Provider<TemplateService>((ref) {
+  return TemplateService(ref.watch(templateRepositoryProvider));
+});
+
+final suggestionServiceProvider = Provider<SuggestionService>((ref) {
+  return SuggestionService(ref.watch(autocompleteRepositoryProvider));
 });

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -8,6 +8,8 @@ import '../features/settings/settings_screen.dart';
 import '../features/summary/monthly_summary_screen.dart';
 import '../features/transactions/transaction_detail_screen.dart';
 import '../features/transactions/transaction_edit_screen.dart';
+import '../features/transactions/transaction_create_screen.dart';
+import '../features/search/search_screen.dart';
 import '../features/budget/budget_screen.dart';
 
 final GoRouter choboRouter = GoRouter(
@@ -33,6 +35,10 @@ final GoRouter choboRouter = GoRouter(
       builder: (context, state) => const RecurringScreen(),
     ),
     GoRoute(
+      path: '/search',
+      builder: (context, state) => const SearchScreen(),
+    ),
+    GoRoute(
       path: '/summary/:month',
       builder: (context, state) {
         return MonthlySummaryScreen(
@@ -46,6 +52,13 @@ final GoRouter choboRouter = GoRouter(
         return BudgetScreen(
           month: state.pathParameters['month']!,
         );
+      },
+    ),
+    GoRoute(
+      path: '/transactions/new',
+      builder: (context, state) {
+        final templateId = state.uri.queryParameters['template'];
+        return TransactionCreateScreen(templateId: templateId);
       },
     ),
     GoRoute(

--- a/lib/data/local_db/chobo_migration.dart
+++ b/lib/data/local_db/chobo_migration.dart
@@ -53,6 +53,9 @@ class ChoboMigration {
           case 9:
             await _applyVersion9(migrator);
             break;
+          case 10:
+            await _applyVersion10(migrator);
+            break;
           default:
             throw UnsupportedError(
               'Schema migration to v$version is not implemented yet.',
@@ -304,6 +307,62 @@ class ChoboMigration {
     );
     await migrator.database.customStatement(
       'PRAGMA user_version = 9;',
+    );
+  }
+
+  static Future<void> _applyVersion10(Migrator migrator) async {
+    await migrator.database.customStatement(
+      '''
+      CREATE TABLE IF NOT EXISTS transaction_templates (
+        template_id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        transaction_type TEXT NOT NULL CHECK (transaction_type IN ('income', 'expense', 'transfer', 'credit_expense', 'liability_payment', 'advance_payment', 'reimbursement')),
+        entries_template TEXT NOT NULL,
+        default_description TEXT,
+        usage_count INTEGER NOT NULL DEFAULT 0,
+        last_used_at TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      ''',
+    );
+    await migrator.database.customStatement(
+      '''
+      CREATE TABLE IF NOT EXISTS recent_selections (
+        selection_id TEXT PRIMARY KEY,
+        field_type TEXT NOT NULL CHECK (field_type IN ('account', 'counterparty', 'description', 'tag')),
+        field_value TEXT NOT NULL,
+        transaction_type TEXT,
+        frequency INTEGER NOT NULL DEFAULT 1,
+        last_selected_at TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        UNIQUE(field_type, field_value, transaction_type)
+      );
+      ''',
+    );
+    await migrator.database.customStatement(
+      'CREATE INDEX IF NOT EXISTS idx_transaction_templates_name ON transaction_templates(name);',
+    );
+    await migrator.database.customStatement(
+      'CREATE INDEX IF NOT EXISTS idx_transaction_templates_usage ON transaction_templates(usage_count DESC);',
+    );
+    await migrator.database.customStatement(
+      'CREATE INDEX IF NOT EXISTS idx_recent_selections_field_type ON recent_selections(field_type);',
+    );
+    await migrator.database.customStatement(
+      'CREATE INDEX IF NOT EXISTS idx_recent_selections_frequency ON recent_selections(frequency DESC);',
+    );
+    await migrator.database.customStatement(
+      'CREATE INDEX IF NOT EXISTS idx_recent_selections_last_selected ON recent_selections(last_selected_at DESC);',
+    );
+    await migrator.database.customStatement(
+      'CREATE INDEX IF NOT EXISTS idx_transactions_description ON transactions(description);',
+    );
+    await migrator.database.customStatement(
+      'CREATE INDEX IF NOT EXISTS idx_transactions_date_type_status ON transactions(date, type, status);',
+    );
+    await migrator.database.customStatement(
+      'PRAGMA user_version = 10;',
     );
   }
 }

--- a/lib/data/local_db/chobo_records.dart
+++ b/lib/data/local_db/chobo_records.dart
@@ -936,6 +936,150 @@ class ChoboBudgetRecord {
   }
 }
 
+class ChoboTransactionTemplateRecord {
+  const ChoboTransactionTemplateRecord({
+    required this.templateId,
+    required this.name,
+    required this.transactionType,
+    required this.entriesTemplate,
+    this.defaultDescription,
+    this.usageCount = 0,
+    this.lastUsedAt,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final String templateId;
+  final String name;
+  final String transactionType;
+  final String entriesTemplate;
+  final String? defaultDescription;
+  final int usageCount;
+  final String? lastUsedAt;
+  final String createdAt;
+  final String updatedAt;
+
+  ChoboTransactionTemplateRecord copyWith({
+    String? templateId,
+    String? name,
+    String? transactionType,
+    String? entriesTemplate,
+    String? defaultDescription,
+    int? usageCount,
+    String? lastUsedAt,
+    String? createdAt,
+    String? updatedAt,
+  }) {
+    return ChoboTransactionTemplateRecord(
+      templateId: templateId ?? this.templateId,
+      name: name ?? this.name,
+      transactionType: transactionType ?? this.transactionType,
+      entriesTemplate: entriesTemplate ?? this.entriesTemplate,
+      defaultDescription: defaultDescription ?? this.defaultDescription,
+      usageCount: usageCount ?? this.usageCount,
+      lastUsedAt: lastUsedAt ?? this.lastUsedAt,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+
+  Map<String, Object?> toDatabaseJson() {
+    return <String, Object?>{
+      'template_id': templateId,
+      'name': name,
+      'transaction_type': transactionType,
+      'entries_template': entriesTemplate,
+      'default_description': defaultDescription,
+      'usage_count': usageCount,
+      'last_used_at': lastUsedAt,
+      'created_at': createdAt,
+      'updated_at': updatedAt,
+    };
+  }
+
+  static ChoboTransactionTemplateRecord fromRow(QueryRow row) {
+    return ChoboTransactionTemplateRecord(
+      templateId: row.read<String>('template_id'),
+      name: row.read<String>('name'),
+      transactionType: row.read<String>('transaction_type'),
+      entriesTemplate: row.read<String>('entries_template'),
+      defaultDescription: row.readNullable<String>('default_description'),
+      usageCount: row.read<int>('usage_count'),
+      lastUsedAt: row.readNullable<String>('last_used_at'),
+      createdAt: row.read<String>('created_at'),
+      updatedAt: row.read<String>('updated_at'),
+    );
+  }
+}
+
+enum SelectionFieldType { account, counterparty, description, tag }
+
+class ChoboRecentSelectionRecord {
+  const ChoboRecentSelectionRecord({
+    required this.selectionId,
+    required this.fieldType,
+    required this.fieldValue,
+    this.transactionType,
+    this.frequency = 1,
+    required this.lastSelectedAt,
+    required this.createdAt,
+  });
+
+  final String selectionId;
+  final SelectionFieldType fieldType;
+  final String fieldValue;
+  final String? transactionType;
+  final int frequency;
+  final String lastSelectedAt;
+  final String createdAt;
+
+  ChoboRecentSelectionRecord copyWith({
+    String? selectionId,
+    SelectionFieldType? fieldType,
+    String? fieldValue,
+    String? transactionType,
+    int? frequency,
+    String? lastSelectedAt,
+    String? createdAt,
+  }) {
+    return ChoboRecentSelectionRecord(
+      selectionId: selectionId ?? this.selectionId,
+      fieldType: fieldType ?? this.fieldType,
+      fieldValue: fieldValue ?? this.fieldValue,
+      transactionType: transactionType ?? this.transactionType,
+      frequency: frequency ?? this.frequency,
+      lastSelectedAt: lastSelectedAt ?? this.lastSelectedAt,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  Map<String, Object?> toDatabaseJson() {
+    return <String, Object?>{
+      'selection_id': selectionId,
+      'field_type': fieldType.name,
+      'field_value': fieldValue,
+      'transaction_type': transactionType,
+      'frequency': frequency,
+      'last_selected_at': lastSelectedAt,
+      'created_at': createdAt,
+    };
+  }
+
+  static ChoboRecentSelectionRecord fromRow(QueryRow row) {
+    return ChoboRecentSelectionRecord(
+      selectionId: row.read<String>('selection_id'),
+      fieldType: SelectionFieldType.values.firstWhere(
+        (e) => e.name == row.read<String>('field_type'),
+      ),
+      fieldValue: row.read<String>('field_value'),
+      transactionType: row.readNullable<String>('transaction_type'),
+      frequency: row.read<int>('frequency'),
+      lastSelectedAt: row.read<String>('last_selected_at'),
+      createdAt: row.read<String>('created_at'),
+    );
+  }
+}
+
 class ChoboBudgetAlertRecord {
   const ChoboBudgetAlertRecord({
     required this.alertId,

--- a/lib/data/local_db/chobo_schema.dart
+++ b/lib/data/local_db/chobo_schema.dart
@@ -1,7 +1,7 @@
 class ChoboSchema {
   ChoboSchema._();
 
-  static const int schemaVersion = 9;
+  static const int schemaVersion = 10;
 
   static const String databaseFileName = 'chobo.sqlite';
 
@@ -19,6 +19,8 @@ class ChoboSchema {
   static const String counterpartiesTable = 'counterparties';
   static const String budgetsTable = 'budgets';
   static const String budgetAlertsTable = 'budget_alerts';
+  static const String transactionTemplatesTable = 'transaction_templates';
+  static const String recentSelectionsTable = 'recent_selections';
 
   static const List<String> createStatements = <String>[
     _createAccountsTable,
@@ -35,6 +37,8 @@ class ChoboSchema {
     _createCounterpartiesTable,
     _createBudgetsTable,
     _createBudgetAlertsTable,
+    _createTransactionTemplatesTable,
+    _createRecentSelectionsTable,
   ];
 
   static const List<String> createIndexStatements = <String>[
@@ -62,6 +66,13 @@ class ChoboSchema {
     'CREATE INDEX IF NOT EXISTS idx_budgets_month ON budgets(month);',
     'CREATE INDEX IF NOT EXISTS idx_budget_alerts_budget_id ON budget_alerts(budget_id);',
     'CREATE INDEX IF NOT EXISTS idx_budget_alerts_triggered_at ON budget_alerts(triggered_at);',
+    'CREATE INDEX IF NOT EXISTS idx_transaction_templates_name ON transaction_templates(name);',
+    'CREATE INDEX IF NOT EXISTS idx_transaction_templates_usage ON transaction_templates(usage_count DESC);',
+    'CREATE INDEX IF NOT EXISTS idx_recent_selections_field_type ON recent_selections(field_type);',
+    'CREATE INDEX IF NOT EXISTS idx_recent_selections_frequency ON recent_selections(frequency DESC);',
+    'CREATE INDEX IF NOT EXISTS idx_recent_selections_last_selected ON recent_selections(last_selected_at DESC);',
+    'CREATE INDEX IF NOT EXISTS idx_transactions_description ON transactions(description);',
+    'CREATE INDEX IF NOT EXISTS idx_transactions_date_type_status ON transactions(date, type, status);',
   ];
 
   static const List<String> createAllStatements = <String>[
@@ -239,6 +250,33 @@ CREATE TABLE IF NOT EXISTS budget_alerts (
   budget_amount INTEGER NOT NULL,
   threshold_percent INTEGER NOT NULL,
   notified INTEGER NOT NULL DEFAULT 0 CHECK (notified IN (0, 1))
+);
+''';
+
+  static const String _createTransactionTemplatesTable = '''
+CREATE TABLE IF NOT EXISTS transaction_templates (
+  template_id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  transaction_type TEXT NOT NULL CHECK (transaction_type IN ('income', 'expense', 'transfer', 'credit_expense', 'liability_payment', 'advance_payment', 'reimbursement')),
+  entries_template TEXT NOT NULL,
+  default_description TEXT,
+  usage_count INTEGER NOT NULL DEFAULT 0,
+  last_used_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+''';
+
+  static const String _createRecentSelectionsTable = '''
+CREATE TABLE IF NOT EXISTS recent_selections (
+  selection_id TEXT PRIMARY KEY,
+  field_type TEXT NOT NULL CHECK (field_type IN ('account', 'counterparty', 'description', 'tag')),
+  field_value TEXT NOT NULL,
+  transaction_type TEXT,
+  frequency INTEGER NOT NULL DEFAULT 1,
+  last_selected_at TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  UNIQUE(field_type, field_value, transaction_type)
 );
 ''';
 }

--- a/lib/data/models/search_models.dart
+++ b/lib/data/models/search_models.dart
@@ -1,0 +1,117 @@
+enum FilterLogic { and, or }
+
+enum SortField { date, amount, createdAt }
+
+enum SortOrder { ascending, descending }
+
+class SearchFilter {
+  const SearchFilter({
+    this.dateFrom,
+    this.dateTo,
+    this.accountIds,
+    this.type,
+    this.status,
+    this.tagIds,
+    this.counterpartyId,
+    this.amountMin,
+    this.amountMax,
+    this.descriptionContains,
+  });
+
+  final String? dateFrom;
+  final String? dateTo;
+  final List<String>? accountIds;
+  final String? type;
+  final String? status;
+  final List<String>? tagIds;
+  final String? counterpartyId;
+  final int? amountMin;
+  final int? amountMax;
+  final String? descriptionContains;
+
+  bool get isEmpty =>
+      dateFrom == null &&
+      dateTo == null &&
+      (accountIds == null || accountIds!.isEmpty) &&
+      type == null &&
+      status == null &&
+      (tagIds == null || tagIds!.isEmpty) &&
+      counterpartyId == null &&
+      amountMin == null &&
+      amountMax == null &&
+      descriptionContains == null;
+
+  SearchFilter copyWith({
+    String? dateFrom,
+    String? dateTo,
+    List<String>? accountIds,
+    String? type,
+    String? status,
+    List<String>? tagIds,
+    String? counterpartyId,
+    int? amountMin,
+    int? amountMax,
+    String? descriptionContains,
+  }) {
+    return SearchFilter(
+      dateFrom: dateFrom ?? this.dateFrom,
+      dateTo: dateTo ?? this.dateTo,
+      accountIds: accountIds ?? this.accountIds,
+      type: type ?? this.type,
+      status: status ?? this.status,
+      tagIds: tagIds ?? this.tagIds,
+      counterpartyId: counterpartyId ?? this.counterpartyId,
+      amountMin: amountMin ?? this.amountMin,
+      amountMax: amountMax ?? this.amountMax,
+      descriptionContains: descriptionContains ?? this.descriptionContains,
+    );
+  }
+}
+
+class SearchQuery {
+  const SearchQuery({
+    required this.filter,
+    this.filterLogic = FilterLogic.and,
+    this.sortField = SortField.date,
+    this.sortOrder = SortOrder.descending,
+    this.limit = 50,
+    this.offset = 0,
+  });
+
+  final SearchFilter filter;
+  final FilterLogic filterLogic;
+  final SortField sortField;
+  final SortOrder sortOrder;
+  final int limit;
+  final int offset;
+
+  SearchQuery copyWith({
+    SearchFilter? filter,
+    FilterLogic? filterLogic,
+    SortField? sortField,
+    SortOrder? sortOrder,
+    int? limit,
+    int? offset,
+  }) {
+    return SearchQuery(
+      filter: filter ?? this.filter,
+      filterLogic: filterLogic ?? this.filterLogic,
+      sortField: sortField ?? this.sortField,
+      sortOrder: sortOrder ?? this.sortOrder,
+      limit: limit ?? this.limit,
+      offset: offset ?? this.offset,
+    );
+  }
+}
+
+class SearchResult<T> {
+  const SearchResult({
+    required this.items,
+    required this.totalCount,
+    required this.hasMore,
+  });
+
+  final List<T> items;
+  final int totalCount;
+  final bool hasMore;
+}

--- a/lib/data/repository/autocomplete_repository.dart
+++ b/lib/data/repository/autocomplete_repository.dart
@@ -1,0 +1,167 @@
+import 'package:drift/drift.dart';
+
+import '../local_db/app_database.dart';
+import '../local_db/chobo_records.dart';
+
+class AutocompleteRepository {
+  AutocompleteRepository(this._db);
+
+  final AppDatabase _db;
+
+  Future<List<ChoboRecentSelectionRecord>> getRecentSuggestions({
+    required SelectionFieldType fieldType,
+    String? transactionType,
+    int limit = 10,
+  }) async {
+    String whereClause = 'WHERE field_type = ?';
+    List<Variable<Object>> variables = [Variable<Object>(fieldType.name)];
+
+    if (transactionType != null) {
+      whereClause += ' AND (transaction_type = ? OR transaction_type IS NULL)';
+      variables.add(Variable<Object>(transactionType));
+    }
+
+    final rows = await _db.customSelect(
+      '''
+      SELECT selection_id, field_type, field_value, transaction_type,
+             frequency, last_selected_at, created_at
+      FROM recent_selections
+      $whereClause
+      ORDER BY last_selected_at DESC
+      LIMIT ?
+      ''',
+      variables: [...variables, Variable<Object>(limit)],
+    ).get();
+
+    return rows.map(ChoboRecentSelectionRecord.fromRow).toList();
+  }
+
+  Future<List<ChoboRecentSelectionRecord>> getFrequentSuggestions({
+    required SelectionFieldType fieldType,
+    String? transactionType,
+    int limit = 10,
+  }) async {
+    String whereClause = 'WHERE field_type = ?';
+    List<Variable<Object>> variables = [Variable<Object>(fieldType.name)];
+
+    if (transactionType != null) {
+      whereClause += ' AND (transaction_type = ? OR transaction_type IS NULL)';
+      variables.add(Variable<Object>(transactionType));
+    }
+
+    final rows = await _db.customSelect(
+      '''
+      SELECT selection_id, field_type, field_value, transaction_type,
+             frequency, last_selected_at, created_at
+      FROM recent_selections
+      $whereClause
+      ORDER BY frequency DESC, last_selected_at DESC
+      LIMIT ?
+      ''',
+      variables: [...variables, Variable<Object>(limit)],
+    ).get();
+
+    return rows.map(ChoboRecentSelectionRecord.fromRow).toList();
+  }
+
+  Future<List<ChoboRecentSelectionRecord>> getSmartSuggestions({
+    required SelectionFieldType fieldType,
+    String? transactionType,
+    int limit = 10,
+  }) async {
+    String whereClause = 'WHERE field_type = ?';
+    List<Variable<Object>> variables = [Variable<Object>(fieldType.name)];
+
+    if (transactionType != null) {
+      whereClause += ' AND (transaction_type = ? OR transaction_type IS NULL)';
+      variables.add(Variable<Object>(transactionType));
+    }
+
+    final rows = await _db.customSelect(
+      '''
+      SELECT selection_id, field_type, field_value, transaction_type,
+             frequency, last_selected_at, created_at
+      FROM recent_selections
+      $whereClause
+      ORDER BY (frequency * 0.3 + (
+        SELECT COUNT(*) FROM recent_selections
+      ) - CAST(strftime('%s', 'now') - strftime('%s', last_selected_at) AS INTEGER) / 86400 * 0.1) DESC
+      LIMIT ?
+      ''',
+      variables: [...variables, Variable<Object>(limit)],
+    ).get();
+
+    return rows.map(ChoboRecentSelectionRecord.fromRow).toList();
+  }
+
+  Future<void> recordSelection(ChoboRecentSelectionRecord selection) async {
+    final existing = await _db.customSelect(
+      '''
+      SELECT selection_id, field_type, field_value, transaction_type,
+             frequency, last_selected_at, created_at
+      FROM recent_selections
+      WHERE field_type = ? AND field_value = ? AND (transaction_type = ? OR (transaction_type IS NULL AND ? IS NULL))
+      ''',
+      variables: <Variable>[
+        Variable(selection.fieldType.name),
+        Variable(selection.fieldValue),
+        Variable(selection.transactionType),
+        Variable(selection.transactionType),
+      ],
+    ).getSingleOrNull();
+
+    final now = DateTime.now().toUtc().toIso8601String();
+
+    if (existing != null) {
+      final existingRecord = ChoboRecentSelectionRecord.fromRow(existing);
+      await _db.customUpdate(
+        '''
+        UPDATE recent_selections
+        SET frequency = frequency + 1,
+            last_selected_at = ?,
+            created_at = COALESCE(created_at, ?)
+        WHERE selection_id = ?
+        ''',
+        variables: <Variable>[
+          Variable(now),
+          Variable(existingRecord.createdAt),
+          Variable(existingRecord.selectionId),
+        ],
+      );
+    } else {
+      await _db.customInsert(
+        '''
+        INSERT INTO recent_selections (
+          selection_id,
+          field_type,
+          field_value,
+          transaction_type,
+          frequency,
+          last_selected_at,
+          created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        ''',
+        variables: <Variable>[
+          Variable(selection.selectionId),
+          Variable(selection.fieldType.name),
+          Variable(selection.fieldValue),
+          Variable(selection.transactionType),
+          Variable(selection.frequency),
+          Variable(now),
+          Variable(now),
+        ],
+      );
+    }
+  }
+
+  Future<void> pruneOldSelections({int maxAgeInDays = 90}) async {
+    await _db.customUpdate(
+      '''
+      DELETE FROM recent_selections
+      WHERE last_selected_at < date('now', ?)
+      AND frequency < 3
+      ''',
+      variables: <Variable>[Variable('-$maxAgeInDays days')],
+    );
+  }
+}

--- a/lib/data/repository/template_repository.dart
+++ b/lib/data/repository/template_repository.dart
@@ -1,0 +1,164 @@
+import 'package:drift/drift.dart';
+
+import '../local_db/app_database.dart';
+import '../local_db/chobo_records.dart';
+
+class TemplateRepository {
+  TemplateRepository(this._db);
+
+  final AppDatabase _db;
+
+  Future<List<ChoboTransactionTemplateRecord>> listTemplates({
+    String? transactionType,
+    bool orderByUsage = true,
+  }) async {
+    String orderClause = orderByUsage
+        ? 'ORDER BY usage_count DESC, name ASC'
+        : 'ORDER BY name ASC';
+
+    String whereClause = '';
+    List<Variable> variables = [];
+
+    if (transactionType != null) {
+      whereClause = 'WHERE transaction_type = ?';
+      variables = [Variable(transactionType)];
+    }
+
+    final List<Variable<Object>> sqlVariables = variables.isEmpty
+        ? <Variable<Object>>[]
+        : variables.map((v) => Variable<Object>(v.value as Object)).toList();
+
+    final rows = await _db.customSelect(
+      '''
+      SELECT template_id, name, transaction_type, entries_template,
+             default_description, usage_count, last_used_at,
+             created_at, updated_at
+      FROM transaction_templates
+      $whereClause
+      $orderClause
+      ''',
+      variables: sqlVariables,
+    ).get();
+
+    return rows.map(ChoboTransactionTemplateRecord.fromRow).toList();
+  }
+
+  Future<ChoboTransactionTemplateRecord?> getTemplate(String templateId) async {
+    final rows = await _db.customSelect(
+      '''
+      SELECT template_id, name, transaction_type, entries_template,
+             default_description, usage_count, last_used_at,
+             created_at, updated_at
+      FROM transaction_templates
+      WHERE template_id = ?
+      ''',
+      variables: <Variable>[Variable(templateId)],
+    ).getSingleOrNull();
+
+    return rows == null ? null : ChoboTransactionTemplateRecord.fromRow(rows);
+  }
+
+  Future<void> createTemplate(ChoboTransactionTemplateRecord template) async {
+    await _db.customInsert(
+      '''
+      INSERT INTO transaction_templates (
+        template_id,
+        name,
+        transaction_type,
+        entries_template,
+        default_description,
+        usage_count,
+        last_used_at,
+        created_at,
+        updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ''',
+      variables: _templateVariables(template),
+    );
+  }
+
+  Future<int> updateTemplate(ChoboTransactionTemplateRecord template) async {
+    return await _db.customUpdate(
+      '''
+      UPDATE transaction_templates
+      SET name = ?,
+          transaction_type = ?,
+          entries_template = ?,
+          default_description = ?,
+          usage_count = ?,
+          last_used_at = ?,
+          updated_at = ?
+      WHERE template_id = ?
+      ''',
+      variables: <Variable>[
+        Variable(template.name),
+        Variable(template.transactionType),
+        Variable(template.entriesTemplate),
+        Variable(template.defaultDescription),
+        Variable(template.usageCount),
+        Variable(template.lastUsedAt),
+        Variable(template.updatedAt),
+        Variable(template.templateId),
+      ],
+    );
+  }
+
+  Future<int> deleteTemplate(String templateId) async {
+    return await _db.customUpdate(
+      'DELETE FROM transaction_templates WHERE template_id = ?',
+      variables: <Variable>[Variable(templateId)],
+    );
+  }
+
+  Future<void> incrementUsage(String templateId) async {
+    final now = DateTime.now().toUtc().toIso8601String();
+    await _db.customUpdate(
+      '''
+      UPDATE transaction_templates
+      SET usage_count = usage_count + 1,
+          last_used_at = ?,
+          updated_at = ?
+      WHERE template_id = ?
+      ''',
+      variables: <Variable>[
+        Variable(now),
+        Variable(now),
+        Variable(templateId),
+      ],
+    );
+  }
+
+  Future<List<ChoboTransactionTemplateRecord>> getSuggestedTemplates({
+    required String transactionType,
+    int limit = 5,
+  }) async {
+    final rows = await _db.customSelect(
+      '''
+      SELECT template_id, name, transaction_type, entries_template,
+             default_description, usage_count, last_used_at,
+             created_at, updated_at
+      FROM transaction_templates
+      WHERE transaction_type = ?
+      ORDER BY usage_count DESC, last_used_at DESC
+      LIMIT ?
+      ''',
+      variables: <Variable>[Variable(transactionType), Variable(limit)],
+    ).get();
+
+    return rows.map(ChoboTransactionTemplateRecord.fromRow).toList();
+  }
+
+  List<Variable> _templateVariables(ChoboTransactionTemplateRecord template) {
+    return <Variable>[
+      Variable(template.templateId),
+      Variable(template.name),
+      Variable(template.transactionType),
+      Variable(template.entriesTemplate),
+      Variable(template.defaultDescription),
+      Variable(template.usageCount),
+      Variable(template.lastUsedAt),
+      Variable(template.createdAt),
+      Variable(template.updatedAt),
+    ];
+  }
+}

--- a/lib/data/repository/transaction_search_repository.dart
+++ b/lib/data/repository/transaction_search_repository.dart
@@ -1,0 +1,156 @@
+import 'package:drift/drift.dart';
+
+import '../local_db/app_database.dart';
+import '../local_db/chobo_records.dart';
+import '../models/search_models.dart';
+
+class TransactionSearchRepository {
+  TransactionSearchRepository(this._db);
+
+  final AppDatabase _db;
+
+  Future<SearchResult<ChoboTransactionRecord>> search(
+    SearchQuery query,
+  ) async {
+    if (query.filter.isEmpty) {
+      final transactions = await _listRecentTransactions(
+        query.limit,
+        query.offset,
+      );
+      final total = await _countRecentTransactions();
+      return SearchResult(
+        items: transactions,
+        totalCount: total,
+        hasMore: query.offset + transactions.length < total,
+      );
+    }
+
+    final conditions = <String>[];
+    final variables = <Variable>[];
+
+    _buildConditions(query.filter, conditions, variables);
+
+    final whereClause =
+        conditions.isEmpty ? '' : 'WHERE ${conditions.join(' AND ')}';
+
+    final needsEntriesJoin = query.filter.accountIds != null;
+    final needsTagsJoin = query.filter.tagIds != null;
+
+    final orderColumn = switch (query.sortField) {
+      SortField.date => 't.date',
+      SortField.amount => 'e.amount',
+      SortField.createdAt => 't.created_at',
+    };
+
+    final orderDirection =
+        query.sortOrder == SortOrder.ascending ? 'ASC' : 'DESC';
+
+    final baseSql = '''
+      SELECT DISTINCT t.transaction_id, t.date, t.type, t.status,
+             t.description, t.counterparty, t.counterparty_id,
+             t.external_ref, t.original_transaction_id, t.refund_type,
+             t.period_lock_state, t.created_at, t.updated_at
+      FROM transactions t
+      ${needsEntriesJoin ? 'INNER JOIN entries e ON t.transaction_id = e.transaction_id' : ''}
+      ${needsTagsJoin ? 'INNER JOIN transaction_tags tt ON t.transaction_id = tt.transaction_id' : ''}
+      $whereClause
+      ORDER BY $orderColumn $orderDirection
+      LIMIT ? OFFSET ?
+    ''';
+
+    final countSql = '''
+      SELECT COUNT(DISTINCT t.transaction_id) as count
+      FROM transactions t
+      ${needsEntriesJoin ? 'INNER JOIN entries e ON t.transaction_id = e.transaction_id' : ''}
+      ${needsTagsJoin ? 'INNER JOIN transaction_tags tt ON t.transaction_id = tt.transaction_id' : ''}
+      $whereClause
+    ''';
+
+    final allVariables = [
+      ...variables,
+      Variable(query.limit),
+      Variable(query.offset)
+    ];
+    final rows = await _db.customSelect(baseSql, variables: allVariables).get();
+    final transactions = rows.map(ChoboTransactionRecord.fromRow).toList();
+
+    final countRows =
+        await _db.customSelect(countSql, variables: variables).get();
+    final totalCount = countRows.first.read<int>('count');
+
+    return SearchResult(
+      items: transactions,
+      totalCount: totalCount,
+      hasMore: query.offset + transactions.length < totalCount,
+    );
+  }
+
+  void _buildConditions(
+    SearchFilter filter,
+    List<String> conditions,
+    List<Variable> variables,
+  ) {
+    if (filter.dateFrom != null) {
+      conditions.add('t.date >= ?');
+      variables.add(Variable(filter.dateFrom!));
+    }
+    if (filter.dateTo != null) {
+      conditions.add('t.date <= ?');
+      variables.add(Variable(filter.dateTo!));
+    }
+    if (filter.type != null) {
+      conditions.add('t.type = ?');
+      variables.add(Variable(filter.type!));
+    }
+    if (filter.status != null) {
+      conditions.add('t.status = ?');
+      variables.add(Variable(filter.status!));
+    }
+    if (filter.accountIds != null && filter.accountIds!.isNotEmpty) {
+      final placeholders = filter.accountIds!.map((_) => '?').join(', ');
+      conditions.add('e.account_id IN ($placeholders)');
+      variables.addAll(filter.accountIds!.map((id) => Variable(id)));
+    }
+    if (filter.tagIds != null && filter.tagIds!.isNotEmpty) {
+      final placeholders = filter.tagIds!.map((_) => '?').join(', ');
+      conditions.add('tt.tag_id IN ($placeholders)');
+      variables.addAll(filter.tagIds!.map((id) => Variable(id)));
+    }
+    if (filter.counterpartyId != null) {
+      conditions.add('t.counterparty_id = ?');
+      variables.add(Variable(filter.counterpartyId!));
+    }
+    if (filter.descriptionContains != null &&
+        filter.descriptionContains!.isNotEmpty) {
+      conditions.add('t.description LIKE ?');
+      variables.add(Variable('%${filter.descriptionContains!}%'));
+    }
+  }
+
+  Future<List<ChoboTransactionRecord>> _listRecentTransactions(
+    int limit,
+    int offset,
+  ) async {
+    final rows = await _db.customSelect(
+      '''
+      SELECT transaction_id, date, type, status, description, counterparty,
+             counterparty_id, external_ref, original_transaction_id, refund_type,
+             period_lock_state, created_at, updated_at
+      FROM transactions
+      ORDER BY date DESC, created_at DESC, transaction_id DESC
+      LIMIT ? OFFSET ?
+      ''',
+      variables: <Variable>[Variable(limit), Variable(offset)],
+    ).get();
+    return rows.map(ChoboTransactionRecord.fromRow).toList();
+  }
+
+  Future<int> _countRecentTransactions() async {
+    final rows = await _db
+        .customSelect(
+          'SELECT COUNT(*) as count FROM transactions',
+        )
+        .get();
+    return rows.first.read<int>('count');
+  }
+}

--- a/lib/data/service/suggestion_service.dart
+++ b/lib/data/service/suggestion_service.dart
@@ -1,0 +1,235 @@
+import 'dart:async';
+
+import '../local_db/chobo_records.dart';
+import '../repository/autocomplete_repository.dart';
+
+class SuggestionResult {
+  const SuggestionResult({
+    required this.value,
+    required this.displayText,
+    this.subtitle,
+    this.score = 0.0,
+    this.source = SuggestionSource.recent,
+  });
+
+  final String value;
+  final String displayText;
+  final String? subtitle;
+  final double score;
+  final SuggestionSource source;
+
+  SuggestionResult copyWith({
+    String? value,
+    String? displayText,
+    String? subtitle,
+    double? score,
+    SuggestionSource? source,
+  }) {
+    return SuggestionResult(
+      value: value ?? this.value,
+      displayText: displayText ?? this.displayText,
+      subtitle: subtitle ?? this.subtitle,
+      score: score ?? this.score,
+      source: source ?? this.source,
+    );
+  }
+}
+
+enum SuggestionSource {
+  recent,
+  frequent,
+  smart,
+  search,
+  template,
+}
+
+class SuggestionService {
+  SuggestionService(this._repository);
+
+  final AutocompleteRepository _repository;
+
+  DateTime? _lastCallTime;
+  static const Duration _defaultDebounce = Duration(milliseconds: 300);
+
+  Future<List<SuggestionResult>> getSuggestions({
+    required SelectionFieldType fieldType,
+    String? query,
+    String? transactionType,
+    int limit = 10,
+    bool debounce = true,
+  }) async {
+    if (debounce) {
+      final now = DateTime.now();
+      final elapsed =
+          _lastCallTime != null ? now.difference(_lastCallTime!) : null;
+      if (elapsed != null && elapsed < _defaultDebounce) {
+        await Future.delayed(_defaultDebounce - elapsed);
+      }
+      _lastCallTime = DateTime.now();
+    }
+
+    final recents = await _repository.getRecentSuggestions(
+      fieldType: fieldType,
+      transactionType: transactionType,
+      limit: limit,
+    );
+
+    final frequents = await _repository.getFrequentSuggestions(
+      fieldType: fieldType,
+      transactionType: transactionType,
+      limit: limit,
+    );
+
+    final smartSuggestions = await _repository.getSmartSuggestions(
+      fieldType: fieldType,
+      transactionType: transactionType,
+      limit: limit,
+    );
+
+    final suggestions = <SuggestionResult>[];
+
+    final seenValues = <String>{};
+
+    for (final r in recents) {
+      if (!seenValues.contains(r.fieldValue)) {
+        seenValues.add(r.fieldValue);
+        suggestions.add(_toSuggestionResult(r, SuggestionSource.recent));
+      }
+    }
+
+    for (final f in frequents) {
+      if (!seenValues.contains(f.fieldValue)) {
+        seenValues.add(f.fieldValue);
+        suggestions.add(_toSuggestionResult(f, SuggestionSource.frequent));
+      }
+    }
+
+    for (final s in smartSuggestions) {
+      if (!seenValues.contains(s.fieldValue)) {
+        seenValues.add(s.fieldValue);
+        suggestions.add(_toSuggestionResult(s, SuggestionSource.smart));
+      }
+    }
+
+    if (query != null && query.isNotEmpty) {
+      final filtered = suggestions.where((s) {
+        return s.value.toLowerCase().contains(query.toLowerCase()) ||
+            s.displayText.toLowerCase().contains(query.toLowerCase());
+      }).toList();
+
+      final sorted = _sortByRelevance(filtered, query);
+      return sorted.take(limit).toList();
+    }
+
+    return _sortByScore(suggestions).take(limit).toList();
+  }
+
+  Future<List<SuggestionResult>> getQuickSuggestions({
+    required SelectionFieldType fieldType,
+    String? transactionType,
+    int limit = 5,
+  }) async {
+    return getSuggestions(
+      fieldType: fieldType,
+      transactionType: transactionType,
+      limit: limit,
+      debounce: false,
+    );
+  }
+
+  Future<void> recordSelection({
+    required SelectionFieldType fieldType,
+    required String value,
+    String? transactionType,
+  }) async {
+    final record = ChoboRecentSelectionRecord(
+      selectionId: 'sel_${DateTime.now().millisecondsSinceEpoch}',
+      fieldType: fieldType,
+      fieldValue: value,
+      transactionType: transactionType,
+      frequency: 1,
+      lastSelectedAt: DateTime.now().toUtc().toIso8601String(),
+      createdAt: DateTime.now().toUtc().toIso8601String(),
+    );
+    await _repository.recordSelection(record);
+  }
+
+  Future<void> recordSelections({
+    required List<SelectionFieldType> fieldTypes,
+    required List<String> values,
+    String? transactionType,
+  }) async {
+    for (int i = 0; i < fieldTypes.length && i < values.length; i++) {
+      await recordSelection(
+        fieldType: fieldTypes[i],
+        value: values[i],
+        transactionType: transactionType,
+      );
+    }
+  }
+
+  Future<void> pruneOldSelections({int maxAgeInDays = 90}) async {
+    await _repository.pruneOldSelections(maxAgeInDays: maxAgeInDays);
+  }
+
+  SuggestionResult _toSuggestionResult(
+    ChoboRecentSelectionRecord record,
+    SuggestionSource source,
+  ) {
+    final score = switch (source) {
+      SuggestionSource.recent => 0.4,
+      SuggestionSource.frequent => 0.3,
+      SuggestionSource.smart => 0.5,
+      SuggestionSource.search => 0.2,
+      SuggestionSource.template => 0.1,
+    };
+
+    return SuggestionResult(
+      value: record.fieldValue,
+      displayText: record.fieldValue,
+      subtitle: _formatSubtitle(record),
+      score: score + (record.frequency * 0.01),
+      source: source,
+    );
+  }
+
+  String? _formatSubtitle(ChoboRecentSelectionRecord record) {
+    if (record.frequency > 1) {
+      return '${record.frequency}回使用';
+    }
+    return null;
+  }
+
+  List<SuggestionResult> _sortByScore(List<SuggestionResult> suggestions) {
+    final sorted = List<SuggestionResult>.from(suggestions);
+    sorted.sort((a, b) => b.score.compareTo(a.score));
+    return sorted;
+  }
+
+  List<SuggestionResult> _sortByRelevance(
+    List<SuggestionResult> suggestions,
+    String query,
+  ) {
+    final sorted = List<SuggestionResult>.from(suggestions);
+    sorted.sort((a, b) {
+      final aStartsWith = a.value.toLowerCase().startsWith(query.toLowerCase());
+      final bStartsWith = b.value.toLowerCase().startsWith(query.toLowerCase());
+
+      if (aStartsWith && !bStartsWith) return -1;
+      if (!aStartsWith && bStartsWith) return 1;
+
+      final aContains = a.value.toLowerCase().contains(query.toLowerCase());
+      final bContains = b.value.toLowerCase().contains(query.toLowerCase());
+
+      if (aContains && !bContains) return -1;
+      if (!aContains && bContains) return 1;
+
+      return b.score.compareTo(a.score);
+    });
+    return sorted;
+  }
+
+  void dispose() {
+    // No timers to cancel in this implementation
+  }
+}

--- a/lib/data/service/template_service.dart
+++ b/lib/data/service/template_service.dart
@@ -1,0 +1,176 @@
+import 'dart:convert';
+
+import '../local_db/chobo_records.dart';
+import '../repository/template_repository.dart';
+
+class EntryTemplate {
+  const EntryTemplate({
+    required this.accountId,
+    required this.direction,
+    this.amountRatio,
+    this.memo,
+  });
+
+  final String accountId;
+  final String direction;
+  final double? amountRatio;
+  final String? memo;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'account_id': accountId,
+      'direction': direction,
+      if (amountRatio != null) 'amount_ratio': amountRatio,
+      if (memo != null) 'memo': memo,
+    };
+  }
+
+  static EntryTemplate fromJson(Map<String, dynamic> json) {
+    return EntryTemplate(
+      accountId: json['account_id'] as String,
+      direction: json['direction'] as String,
+      amountRatio: json['amount_ratio'] as double?,
+      memo: json['memo'] as String?,
+    );
+  }
+}
+
+class TransactionTemplate {
+  const TransactionTemplate({
+    required this.templateId,
+    required this.name,
+    required this.transactionType,
+    required this.entries,
+    this.defaultDescription,
+    this.usageCount = 0,
+    this.lastUsedAt,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final String templateId;
+  final String name;
+  final String transactionType;
+  final List<EntryTemplate> entries;
+  final String? defaultDescription;
+  final int usageCount;
+  final String? lastUsedAt;
+  final String createdAt;
+  final String updatedAt;
+
+  String get entriesTemplateJson =>
+      jsonEncode(entries.map((e) => e.toJson()).toList());
+
+  static TransactionTemplate fromRecord(
+    ChoboTransactionTemplateRecord record,
+  ) {
+    final entriesList = (jsonDecode(record.entriesTemplate) as List)
+        .map((e) => EntryTemplate.fromJson(e as Map<String, dynamic>))
+        .toList();
+
+    return TransactionTemplate(
+      templateId: record.templateId,
+      name: record.name,
+      transactionType: record.transactionType,
+      entries: entriesList,
+      defaultDescription: record.defaultDescription,
+      usageCount: record.usageCount,
+      lastUsedAt: record.lastUsedAt,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    );
+  }
+}
+
+class TemplateService {
+  TemplateService(this._repository);
+
+  final TemplateRepository _repository;
+
+  Future<List<TransactionTemplate>> listTemplates({
+    String? transactionType,
+  }) async {
+    final records = await _repository.listTemplates(
+      transactionType: transactionType,
+    );
+    return records.map(TransactionTemplate.fromRecord).toList();
+  }
+
+  Future<TransactionTemplate?> getTemplate(String templateId) async {
+    final record = await _repository.getTemplate(templateId);
+    return record != null ? TransactionTemplate.fromRecord(record) : null;
+  }
+
+  Future<void> createTemplate(TransactionTemplate template) async {
+    final now = DateTime.now().toUtc().toIso8601String();
+    final record = ChoboTransactionTemplateRecord(
+      templateId: template.templateId,
+      name: template.name,
+      transactionType: template.transactionType,
+      entriesTemplate: template.entriesTemplateJson,
+      defaultDescription: template.defaultDescription,
+      usageCount: 0,
+      lastUsedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    );
+    await _repository.createTemplate(record);
+  }
+
+  Future<void> updateTemplate(TransactionTemplate template) async {
+    final record = ChoboTransactionTemplateRecord(
+      templateId: template.templateId,
+      name: template.name,
+      transactionType: template.transactionType,
+      entriesTemplate: template.entriesTemplateJson,
+      defaultDescription: template.defaultDescription,
+      usageCount: template.usageCount,
+      lastUsedAt: template.lastUsedAt,
+      createdAt: template.createdAt,
+      updatedAt: DateTime.now().toUtc().toIso8601String(),
+    );
+    await _repository.updateTemplate(record);
+  }
+
+  Future<void> deleteTemplate(String templateId) async {
+    await _repository.deleteTemplate(templateId);
+  }
+
+  Future<void> applyTemplate(String templateId) async {
+    await _repository.incrementUsage(templateId);
+  }
+
+  Future<List<TransactionTemplate>> getSuggestedTemplates({
+    required String transactionType,
+    int limit = 5,
+  }) async {
+    final records = await _repository.getSuggestedTemplates(
+      transactionType: transactionType,
+      limit: limit,
+    );
+    return records.map(TransactionTemplate.fromRecord).toList();
+  }
+
+  Future<TransactionTemplate> createFromTransaction({
+    required String name,
+    required String transactionType,
+    required List<EntryTemplate> entries,
+    String? defaultDescription,
+  }) async {
+    final templateId = 'tpl_${DateTime.now().millisecondsSinceEpoch}';
+    final now = DateTime.now().toUtc().toIso8601String();
+
+    final template = TransactionTemplate(
+      templateId: templateId,
+      name: name,
+      transactionType: transactionType,
+      entries: entries,
+      defaultDescription: defaultDescription,
+      createdAt: now,
+      updatedAt: now,
+    );
+
+    await createTemplate(template);
+    return template;
+  }
+}

--- a/lib/data/service/transaction_search_service.dart
+++ b/lib/data/service/transaction_search_service.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+
+import '../local_db/chobo_records.dart';
+import '../models/search_models.dart';
+import '../repository/transaction_search_repository.dart';
+
+class TransactionSearchService {
+  TransactionSearchService(this._repository);
+
+  final TransactionSearchRepository _repository;
+
+  final List<SearchQuery> _recentSearches = [];
+  static const int _maxRecentSearches = 10;
+
+  DateTime? _lastSearchTime;
+  static const Duration _debounceDuration = Duration(milliseconds: 300);
+
+  Future<SearchResult<ChoboTransactionRecord>> search(
+    SearchQuery query, {
+    bool debounce = true,
+  }) async {
+    if (debounce) {
+      final now = DateTime.now();
+      final elapsed =
+          _lastSearchTime != null ? now.difference(_lastSearchTime!) : null;
+      if (elapsed != null && elapsed < _debounceDuration) {
+        await Future.delayed(_debounceDuration - elapsed);
+      }
+      _lastSearchTime = DateTime.now();
+    }
+
+    final result = await _repository.search(query);
+
+    _addToRecentSearches(query);
+
+    return result;
+  }
+
+  Future<SearchResult<ChoboTransactionRecord>> quickSearch({
+    String? description,
+    String? accountId,
+    int limit = 20,
+  }) async {
+    final filter = SearchFilter(
+      descriptionContains: description,
+      accountIds: accountId != null ? [accountId] : null,
+    );
+
+    final query = SearchQuery(
+      filter: filter,
+      limit: limit,
+    );
+
+    return search(query, debounce: false);
+  }
+
+  List<SearchQuery> getRecentSearches() {
+    return List.unmodifiable(_recentSearches);
+  }
+
+  void clearRecentSearches() {
+    _recentSearches.clear();
+  }
+
+  void _addToRecentSearches(SearchQuery query) {
+    if (query.filter.isEmpty) return;
+
+    _recentSearches.removeWhere(
+      (q) => q.filter == query.filter,
+    );
+
+    _recentSearches.insert(0, query);
+
+    if (_recentSearches.length > _maxRecentSearches) {
+      _recentSearches.removeLast();
+    }
+  }
+
+  void dispose() {
+    // No timers to cancel in this implementation
+  }
+}

--- a/lib/features/common/autocomplete_text_field.dart
+++ b/lib/features/common/autocomplete_text_field.dart
@@ -1,0 +1,275 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../../data/local_db/chobo_records.dart';
+import '../../data/service/suggestion_service.dart';
+
+class AutocompleteTextField extends StatefulWidget {
+  const AutocompleteTextField({
+    super.key,
+    required this.fieldType,
+    this.transactionType,
+    required this.onSelected,
+    this.suggestionService,
+    this.placeholder,
+    this.initialValue,
+    this.enabled = true,
+    this.debounceDuration = const Duration(milliseconds: 300),
+    this.maxSuggestions = 10,
+  });
+
+  final SelectionFieldType fieldType;
+  final String? transactionType;
+  final void Function(String value) onSelected;
+  final SuggestionService? suggestionService;
+  final String? placeholder;
+  final String? initialValue;
+  final bool enabled;
+  final Duration debounceDuration;
+  final int maxSuggestions;
+
+  @override
+  State<AutocompleteTextField> createState() => _AutocompleteTextFieldState();
+}
+
+class _AutocompleteTextFieldState extends State<AutocompleteTextField> {
+  final _controller = TextEditingController();
+  final _focusNode = FocusNode();
+  final _layerLink = LayerLink();
+
+  Timer? _debounceTimer;
+  List<SuggestionResult> _suggestions = [];
+  bool _isLoading = false;
+  bool _showSuggestions = false;
+  int _highlightedIndex = -1;
+
+  OverlayEntry? _overlayEntry;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.text = widget.initialValue ?? '';
+    _focusNode.addListener(_onFocusChange);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focusNode.removeListener(_onFocusChange);
+    _focusNode.dispose();
+    _debounceTimer?.cancel();
+    _removeOverlay();
+    super.dispose();
+  }
+
+  void _onFocusChange() {
+    if (_focusNode.hasFocus && _suggestions.isNotEmpty) {
+      _showSuggestionsOverlay();
+    } else {
+      _hideSuggestionsOverlay();
+    }
+  }
+
+  void _onTextChanged(String value) {
+    _debounceTimer?.cancel();
+
+    if (value.isEmpty) {
+      setState(() {
+        _suggestions = [];
+        _showSuggestions = false;
+        _highlightedIndex = -1;
+      });
+      _removeOverlay();
+      return;
+    }
+
+    _debounceTimer = Timer(widget.debounceDuration, () {
+      _loadSuggestions(value);
+    });
+  }
+
+  Future<void> _loadSuggestions(String query) async {
+    setState(() => _isLoading = true);
+
+    try {
+      final suggestions = widget.suggestionService != null
+          ? await widget.suggestionService!.getSuggestions(
+              fieldType: widget.fieldType,
+              query: query,
+              transactionType: widget.transactionType,
+              limit: widget.maxSuggestions,
+              debounce: false,
+            )
+          : <SuggestionResult>[];
+
+      if (mounted) {
+        setState(() {
+          _suggestions = suggestions;
+          _isLoading = false;
+          _showSuggestions = suggestions.isNotEmpty;
+          _highlightedIndex = suggestions.isNotEmpty ? 0 : -1;
+        });
+
+        if (_showSuggestions && _focusNode.hasFocus) {
+          _showSuggestionsOverlay();
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _suggestions = [];
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  void _showSuggestionsOverlay() {
+    if (_suggestions.isEmpty && !_isLoading) return;
+
+    _removeOverlay();
+
+    _overlayEntry = OverlayEntry(
+      builder: (context) => Positioned(
+        width: MediaQuery.of(context).size.width - 32,
+        child: CompositedTransformFollower(
+          link: _layerLink,
+          showWhenUnlinked: false,
+          offset: const Offset(0, 48),
+          child: Material(
+            elevation: 4,
+            borderRadius: BorderRadius.circular(8),
+            child: _buildSuggestionsList(),
+          ),
+        ),
+      ),
+    );
+
+    Overlay.of(context).insert(_overlayEntry!);
+  }
+
+  void _hideSuggestionsOverlay() {
+    _removeOverlay();
+  }
+
+  void _removeOverlay() {
+    _overlayEntry?.remove();
+    _overlayEntry = null;
+  }
+
+  Widget _buildSuggestionsList() {
+    if (_isLoading) {
+      return const Padding(
+        padding: EdgeInsets.all(16),
+        child: Center(
+          child: SizedBox(
+            width: 24,
+            height: 24,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+        ),
+      );
+    }
+
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxHeight: 250),
+      child: ListView.builder(
+        shrinkWrap: true,
+        padding: EdgeInsets.zero,
+        itemCount: _suggestions.length,
+        itemBuilder: (context, index) {
+          final suggestion = _suggestions[index];
+          final isHighlighted = index == _highlightedIndex;
+
+          return InkWell(
+            onTap: () => _selectSuggestion(suggestion),
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              color: isHighlighted ? Theme.of(context).hoverColor : null,
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          suggestion.displayText,
+                          style: Theme.of(context).textTheme.bodyLarge,
+                        ),
+                        if (suggestion.subtitle != null)
+                          Text(
+                            suggestion.subtitle!,
+                            style: Theme.of(context).textTheme.bodySmall,
+                          ),
+                      ],
+                    ),
+                  ),
+                  Icon(
+                    _getSourceIcon(suggestion.source),
+                    size: 16,
+                    color: Theme.of(context).colorScheme.outline,
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  IconData _getSourceIcon(SuggestionSource source) {
+    return switch (source) {
+      SuggestionSource.recent => Icons.history,
+      SuggestionSource.frequent => Icons.trending_up,
+      SuggestionSource.smart => Icons.auto_awesome,
+      SuggestionSource.search => Icons.search,
+      SuggestionSource.template => Icons.bookmark,
+    };
+  }
+
+  void _selectSuggestion(SuggestionResult suggestion) {
+    _controller.text = suggestion.value;
+    _hideSuggestionsOverlay();
+    widget.onSelected(suggestion.value);
+    widget.suggestionService?.recordSelection(
+      fieldType: widget.fieldType,
+      value: suggestion.value,
+      transactionType: widget.transactionType,
+    );
+    _focusNode.unfocus();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CompositedTransformTarget(
+      link: _layerLink,
+      child: TextField(
+        controller: _controller,
+        focusNode: _focusNode,
+        enabled: widget.enabled,
+        decoration: InputDecoration(
+          hintText: widget.placeholder,
+          suffixIcon: _isLoading
+              ? const SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: Padding(
+                    padding: EdgeInsets.all(8),
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                )
+              : null,
+        ),
+        onChanged: _onTextChanged,
+        onTap: () {
+          if (_suggestions.isNotEmpty) {
+            _showSuggestionsOverlay();
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -17,11 +17,21 @@ class HomeScreen extends ConsumerWidget {
         title: const Text('CHOBO'),
         actions: [
           IconButton(
+            icon: const Icon(Icons.search),
+            onPressed: () => context.push('/search'),
+            tooltip: '検索',
+          ),
+          IconButton(
             icon: const Icon(Icons.settings),
             onPressed: () => context.push('/settings'),
             tooltip: 'Settings',
           ),
         ],
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => context.push('/transactions/new'),
+        icon: const Icon(Icons.add),
+        label: const Text('新規取引'),
       ),
       body: Column(
         children: [

--- a/lib/features/search/search_screen.dart
+++ b/lib/features/search/search_screen.dart
@@ -1,0 +1,255 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../app/chobo_providers.dart';
+import '../../data/local_db/chobo_records.dart';
+import '../../data/models/search_models.dart';
+import '../home/transaction_list_tile.dart';
+
+final transactionSearchQueryProvider = StateProvider<SearchQuery>((ref) {
+  return const SearchQuery(filter: SearchFilter());
+});
+
+final transactionSearchResultsProvider =
+    FutureProvider.autoDispose<SearchResult<ChoboTransactionRecord>>(
+        (ref) async {
+  final query = ref.watch(transactionSearchQueryProvider);
+  final repository = ref.watch(transactionSearchRepositoryProvider);
+  return repository.search(query);
+});
+
+class SearchScreen extends ConsumerStatefulWidget {
+  const SearchScreen({super.key});
+
+  @override
+  ConsumerState<SearchScreen> createState() => _SearchScreenState();
+}
+
+class _SearchScreenState extends ConsumerState<SearchScreen> {
+  final _descriptionController = TextEditingController();
+  String? _selectedType;
+  String? _selectedStatus;
+  DateTimeRange? _dateRange;
+
+  @override
+  void dispose() {
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  void _updateSearch() {
+    final filter = SearchFilter(
+      dateFrom: _dateRange?.start.toIso8601String().split('T').first,
+      dateTo: _dateRange?.end.toIso8601String().split('T').first,
+      type: _selectedType,
+      status: _selectedStatus,
+      descriptionContains: _descriptionController.text.isEmpty
+          ? null
+          : _descriptionController.text,
+    );
+
+    ref.read(transactionSearchQueryProvider.notifier).state =
+        SearchQuery(filter: filter);
+  }
+
+  void _clearFilters() {
+    setState(() {
+      _descriptionController.clear();
+      _selectedType = null;
+      _selectedStatus = null;
+      _dateRange = null;
+    });
+    ref.read(transactionSearchQueryProvider.notifier).state = const SearchQuery(
+      filter: SearchFilter(),
+    );
+  }
+
+  Future<void> _selectDateRange() async {
+    final picked = await showDateRangePicker(
+      context: context,
+      firstDate: DateTime(2000),
+      lastDate: DateTime.now().add(const Duration(days: 365)),
+      initialDateRange: _dateRange,
+    );
+    if (picked != null) {
+      setState(() {
+        _dateRange = picked;
+      });
+      _updateSearch();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final resultsAsync = ref.watch(transactionSearchResultsProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('検索'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.filter_list_off),
+            onPressed: _clearFilters,
+            tooltip: 'フィルターをクリア',
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          _buildSearchBar(),
+          _buildFilterChips(),
+          const Divider(height: 1),
+          Expanded(
+            child: resultsAsync.when(
+              data: (result) => _buildResults(result),
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (e, _) => Center(child: Text('検索エラー: $e')),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSearchBar() {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: TextField(
+        controller: _descriptionController,
+        decoration: InputDecoration(
+          hintText: '説明文で検索...',
+          prefixIcon: const Icon(Icons.search),
+          suffixIcon: _descriptionController.text.isNotEmpty
+              ? IconButton(
+                  icon: const Icon(Icons.clear),
+                  onPressed: () {
+                    _descriptionController.clear();
+                    _updateSearch();
+                  },
+                )
+              : null,
+          border: const OutlineInputBorder(),
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: 16,
+            vertical: 12,
+          ),
+        ),
+        onChanged: (_) => _updateSearch(),
+      ),
+    );
+  }
+
+  Widget _buildFilterChips() {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Row(
+        children: [
+          FilterChip(
+            label: Text(_dateRange != null
+                ? '${_formatDate(_dateRange!.start)} - ${_formatDate(_dateRange!.end)}'
+                : '日付範囲'),
+            selected: _dateRange != null,
+            onSelected: (_) => _selectDateRange(),
+          ),
+          const SizedBox(width: 8),
+          ChoiceChip(
+            label: const Text('すべて'),
+            selected: _selectedType == null,
+            onSelected: (_) {
+              setState(() => _selectedType = null);
+              _updateSearch();
+            },
+          ),
+          const SizedBox(width: 8),
+          ...const [
+            'income',
+            'expense',
+            'transfer',
+            'credit_expense',
+            'liability_payment',
+            'advance_payment',
+            'reimbursement'
+          ].map((type) => Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: ChoiceChip(
+                  label: Text(_typeLabel(type)),
+                  selected: _selectedType == type,
+                  onSelected: (selected) {
+                    setState(() => _selectedType = selected ? type : null);
+                    _updateSearch();
+                  },
+                ),
+              )),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildResults(SearchResult<ChoboTransactionRecord> result) {
+    if (result.items.isEmpty) {
+      return const Center(
+        child: Text('検索結果がありません'),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Text(
+            '${result.totalCount}件中 ${result.items.length}件を表示',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+        ),
+        Expanded(
+          child: ListView.builder(
+            padding: const EdgeInsets.all(16),
+            itemCount: result.items.length,
+            itemBuilder: (context, index) {
+              final transaction = result.items[index];
+              return Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: TransactionListTile(transaction: transaction),
+              );
+            },
+          ),
+        ),
+        if (result.hasMore)
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Center(
+              child: TextButton(
+                onPressed: () {
+                  final currentQuery = ref.read(transactionSearchQueryProvider);
+                  ref.read(transactionSearchQueryProvider.notifier).state =
+                      currentQuery.copyWith(
+                    offset: currentQuery.offset + currentQuery.limit,
+                  );
+                },
+                child: const Text('もっと見る'),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+
+  String _formatDate(DateTime date) {
+    return '${date.year}/${date.month.toString().padLeft(2, '0')}/${date.day.toString().padLeft(2, '0')}';
+  }
+
+  String _typeLabel(String type) {
+    return switch (type) {
+      'income' => '収入',
+      'expense' => '支出',
+      'transfer' => '振替',
+      'credit_expense' => '請求',
+      'liability_payment' => '支払',
+      'advance_payment' => '立替',
+      'reimbursement' => '精算',
+      _ => type,
+    };
+  }
+}

--- a/lib/features/transactions/transaction_create_screen.dart
+++ b/lib/features/transactions/transaction_create_screen.dart
@@ -1,0 +1,765 @@
+import 'package:chobo/app/chobo_providers.dart';
+import 'package:chobo/data/local_db/chobo_records.dart';
+import 'package:chobo/data/service/template_service.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../core/terminology_labels.dart';
+import '../../widgets/counterparty_widgets.dart';
+import '../../widgets/tag_widgets.dart';
+import '../common/autocomplete_text_field.dart';
+
+class TransactionCreateScreen extends ConsumerStatefulWidget {
+  const TransactionCreateScreen({
+    super.key,
+    this.templateId,
+  });
+
+  final String? templateId;
+
+  @override
+  ConsumerState<TransactionCreateScreen> createState() =>
+      _TransactionCreateScreenState();
+}
+
+class _TransactionCreateScreenState
+    extends ConsumerState<TransactionCreateScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _dateController = TextEditingController();
+  final _descriptionController = TextEditingController();
+  final _counterpartyController = TextEditingController();
+  final List<TextEditingController> _amountControllers =
+      <TextEditingController>[
+    TextEditingController(),
+    TextEditingController(),
+  ];
+  final List<TextEditingController> _memoControllers = <TextEditingController>[
+    TextEditingController(),
+    TextEditingController(),
+  ];
+
+  List<String?> _selectedAccountIds = <String?>[null, null];
+  List<String> _selectedDirections = <String>['decrease', 'increase'];
+  List<String> _selectedTagIds = [];
+  ChoboCounterpartyRecord? _selectedCounterparty;
+  bool _saving = false;
+  String _selectedType = 'expense';
+  TransactionTemplate? _selectedTemplate;
+
+  TerminologyService get _termService => ref.read(terminologyServiceProvider);
+
+  @override
+  void initState() {
+    super.initState();
+    _dateController.text = DateTime.now().toIso8601String().split('T')[0];
+    if (widget.templateId != null) {
+      _loadTemplate(widget.templateId!);
+    }
+  }
+
+  @override
+  void dispose() {
+    _dateController.dispose();
+    _descriptionController.dispose();
+    _counterpartyController.dispose();
+    for (final controller in _amountControllers) {
+      controller.dispose();
+    }
+    for (final controller in _memoControllers) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  Future<void> _loadTemplate(String templateId) async {
+    final template =
+        await ref.read(templateServiceProvider).getTemplate(templateId);
+    if (template != null && mounted) {
+      setState(() {
+        _selectedTemplate = template;
+        _selectedType = template.transactionType;
+        _descriptionController.text = template.defaultDescription ?? '';
+        _applyTemplateEntries(template);
+      });
+    }
+  }
+
+  void _applyTemplateEntries(TransactionTemplate template) {
+    final maxEntries = _selectedAccountIds.length;
+    for (int i = 0; i < template.entries.length && i < maxEntries; i++) {
+      final entry = template.entries[i];
+      _selectedAccountIds[i] = entry.accountId;
+      _selectedDirections[i] = entry.direction;
+      _memoControllers[i].text = entry.memo ?? '';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accountsAsync = ref.watch(accountsProvider);
+    final templatesAsync = ref.watch(_suggestedTemplatesProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('新規取引'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.bookmark_add),
+            onPressed: () => _showTemplateSelector(context, templatesAsync),
+            tooltip: 'テンプレートを選択',
+          ),
+        ],
+      ),
+      bottomNavigationBar: SafeArea(
+        minimum: const EdgeInsets.all(16),
+        child: FilledButton(
+          onPressed: _saving ? null : () => _save(context),
+          child: _saving
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : Text(_termService.getActionLabel(ActionTerm.save)),
+        ),
+      ),
+      body: accountsAsync.when(
+        data: (accounts) => _buildForm(accounts, templatesAsync),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('エラー: $e')),
+      ),
+    );
+  }
+
+  Widget _buildForm(
+    List<ChoboAccountRecord> accounts,
+    AsyncValue<List<TransactionTemplate>> templatesAsync,
+  ) {
+    return Form(
+      key: _formKey,
+      child: ListView(
+        padding: const EdgeInsets.all(16),
+        children: <Widget>[
+          if (_selectedTemplate != null)
+            Card(
+              color: Theme.of(context).colorScheme.primaryContainer,
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.bookmark,
+                      size: 20,
+                      color: Theme.of(context).colorScheme.onPrimaryContainer,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        'テンプレート: ${_selectedTemplate!.name}',
+                        style: TextStyle(
+                          color:
+                              Theme.of(context).colorScheme.onPrimaryContainer,
+                        ),
+                      ),
+                    ),
+                    IconButton(
+                      icon: Icon(
+                        Icons.close,
+                        size: 18,
+                        color: Theme.of(context).colorScheme.onPrimaryContainer,
+                      ),
+                      onPressed: () {
+                        setState(() {
+                          _selectedTemplate = null;
+                          _selectedAccountIds = [null, null];
+                          _selectedDirections = ['decrease', 'increase'];
+                        });
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          const SizedBox(height: 16),
+          _Section(
+            title: _termService.getSectionLabel(SectionTerm.basicInfo),
+            child: Column(
+              children: <Widget>[
+                TextFormField(
+                  controller: _dateController,
+                  decoration: InputDecoration(
+                    labelText:
+                        _termService.getFieldLabel(FieldTerm.transactionDate),
+                    hintText: '2026-03-22',
+                  ),
+                  validator: (value) {
+                    final text = value?.trim() ?? '';
+                    if (text.isEmpty) {
+                      return '取引日を入力してください。';
+                    }
+                    if (!_looksLikeIsoDate(text)) {
+                      return 'YYYY-MM-DD 形式で入力してください。';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                DropdownButtonFormField<String>(
+                  value: _selectedType,
+                  decoration: InputDecoration(
+                    labelText:
+                        _termService.getFieldLabel(FieldTerm.transactionType),
+                  ),
+                  items: _buildTransactionTypeItems(),
+                  onChanged: (value) {
+                    if (value == null) return;
+                    setState(() {
+                      _selectedType = value;
+                      _updateDirectionsForType(value);
+                    });
+                  },
+                ),
+                const SizedBox(height: 16),
+                AutocompleteTextField(
+                  fieldType: SelectionFieldType.description,
+                  transactionType: _selectedType,
+                  placeholder:
+                      _termService.getFieldLabel(FieldTerm.description),
+                  initialValue: _descriptionController.text,
+                  suggestionService: ref.watch(suggestionServiceProvider),
+                  onSelected: (value) {
+                    _descriptionController.text = value;
+                  },
+                ),
+                const SizedBox(height: 16),
+                CounterpartyAutocomplete(
+                  controller: _counterpartyController,
+                  onSelected: (counterparty) {
+                    setState(() {
+                      _selectedCounterparty = counterparty;
+                    });
+                  },
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          _Section(
+            title: _termService.getSectionLabel(SectionTerm.entries),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                _EntryCard(
+                  entryIndex: 0,
+                  accounts: accounts,
+                  accountId: _selectedAccountIds[0],
+                  onAccountChanged: (value) {
+                    setState(() {
+                      _selectedAccountIds[0] = value;
+                    });
+                    if (value != null && _selectedTemplate == null) {
+                      _recordSelection(SelectionFieldType.account, value);
+                    }
+                  },
+                  direction: _selectedDirections[0],
+                  onDirectionChanged: (value) {
+                    if (value == null) return;
+                    setState(() {
+                      _selectedDirections[0] = value;
+                    });
+                  },
+                  amountController: _amountControllers[0],
+                  memoController: _memoControllers[0],
+                ),
+                const SizedBox(height: 12),
+                _EntryCard(
+                  entryIndex: 1,
+                  accounts: accounts,
+                  accountId: _selectedAccountIds[1],
+                  onAccountChanged: (value) {
+                    setState(() {
+                      _selectedAccountIds[1] = value;
+                    });
+                    if (value != null && _selectedTemplate == null) {
+                      _recordSelection(SelectionFieldType.account, value);
+                    }
+                  },
+                  direction: _selectedDirections[1],
+                  onDirectionChanged: (value) {
+                    if (value == null) return;
+                    setState(() {
+                      _selectedDirections[1] = value;
+                    });
+                  },
+                  amountController: _amountControllers[1],
+                  memoController: _memoControllers[1],
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          _Section(
+            title: 'タグ',
+            child: TagSelector(
+              transactionId: null,
+              selectedTagIds: _selectedTagIds,
+              onTagsChanged: (tagIds) {
+                setState(() {
+                  _selectedTagIds = tagIds;
+                });
+              },
+            ),
+          ),
+          const SizedBox(height: 88),
+        ],
+      ),
+    );
+  }
+
+  void _updateDirectionsForType(String type) {
+    switch (type) {
+      case 'income':
+        _selectedDirections = ['increase', 'increase'];
+        break;
+      case 'expense':
+        _selectedDirections = ['decrease', 'increase'];
+        break;
+      case 'transfer':
+        _selectedDirections = ['decrease', 'increase'];
+        break;
+      case 'credit_expense':
+        _selectedDirections = ['increase', 'increase'];
+        break;
+      case 'liability_payment':
+        _selectedDirections = ['decrease', 'decrease'];
+        break;
+      case 'advance_payment':
+        _selectedDirections = ['decrease', 'increase'];
+        break;
+      case 'reimbursement':
+        _selectedDirections = ['increase', 'increase'];
+        break;
+    }
+  }
+
+  void _recordSelection(SelectionFieldType fieldType, String value) {
+    ref.read(suggestionServiceProvider).recordSelection(
+          fieldType: fieldType,
+          value: value,
+          transactionType: _selectedType,
+        );
+  }
+
+  void _showTemplateSelector(
+    BuildContext context,
+    AsyncValue<List<TransactionTemplate>> templatesAsync,
+  ) {
+    templatesAsync.when(
+      data: (templates) {
+        showModalBottomSheet(
+          context: context,
+          builder: (context) => _TemplateSelectorSheet(
+            templates: templates,
+            onSelected: (template) {
+              Navigator.pop(context);
+              setState(() {
+                _selectedTemplate = template;
+                _selectedType = template.transactionType;
+                _descriptionController.text = template.defaultDescription ?? '';
+                _applyTemplateEntries(template);
+              });
+            },
+          ),
+        );
+      },
+      loading: () {},
+      error: (e, _) => ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('テンプレートの読み込みに失敗: $e')),
+      ),
+    );
+  }
+
+  Future<void> _save(BuildContext context) async {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+    if (_selectedAccountIds.any((value) => value == null)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('明細の口座を選択してください。')),
+      );
+      return;
+    }
+
+    setState(() {
+      _saving = true;
+    });
+
+    try {
+      final counterpartyText = _counterpartyController.text.trim();
+      if (counterpartyText.isNotEmpty && _selectedCounterparty == null) {
+        _selectedCounterparty = await ref
+            .read(counterpartyRepositoryProvider)
+            .getOrCreateCounterparty(rawName: counterpartyText);
+      }
+
+      final now = DateTime.now().toUtc().toIso8601String();
+      final transactionId =
+          'txn_${DateTime.now().toUtc().microsecondsSinceEpoch}';
+
+      final transaction = ChoboTransactionRecord(
+        transactionId: transactionId,
+        date: _dateController.text.trim(),
+        type: _selectedType,
+        status: 'posted',
+        description: _emptyToNull(_descriptionController.text),
+        counterparty: _emptyToNull(_counterpartyController.text),
+        counterpartyId: _selectedCounterparty?.counterpartyId,
+        createdAt: now,
+        updatedAt: now,
+      );
+
+      final entries = <ChoboEntryRecord>[
+        _buildEntry(
+          transactionId: transactionId,
+          index: 0,
+          accountId: _selectedAccountIds[0]!,
+          direction: _selectedDirections[0],
+          amountText: _amountControllers[0].text,
+          memoText: _memoControllers[0].text,
+        ),
+        _buildEntry(
+          transactionId: transactionId,
+          index: 1,
+          accountId: _selectedAccountIds[1]!,
+          direction: _selectedDirections[1],
+          amountText: _amountControllers[1].text,
+          memoText: _memoControllers[1].text,
+        ),
+      ];
+
+      await ref
+          .read(transactionRepositoryProvider)
+          .createTransaction(transaction, entries);
+
+      if (_selectedTagIds.isNotEmpty) {
+        await ref.read(tagRepositoryProvider).setTransactionTags(
+              transactionId: transactionId,
+              tagIds: _selectedTagIds,
+            );
+      }
+
+      if (_selectedCounterparty != null) {
+        _recordSelection(
+          SelectionFieldType.counterparty,
+          _selectedCounterparty!.rawName,
+        );
+      }
+      if (_descriptionController.text.isNotEmpty) {
+        _recordSelection(
+          SelectionFieldType.description,
+          _descriptionController.text,
+        );
+      }
+
+      if (_selectedTemplate != null) {
+        await ref
+            .read(templateServiceProvider)
+            .applyTemplate(_selectedTemplate!.templateId);
+      }
+
+      ref.invalidate(transactionsProvider);
+      if (context.mounted) {
+        context.pop();
+      }
+    } catch (error) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('保存に失敗しました: $error')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _saving = false;
+        });
+      }
+    }
+  }
+
+  ChoboEntryRecord _buildEntry({
+    required String transactionId,
+    required int index,
+    required String accountId,
+    required String direction,
+    required String amountText,
+    required String memoText,
+  }) {
+    final amount = int.tryParse(amountText.trim()) ?? 0;
+    return ChoboEntryRecord(
+      entryId: '${transactionId}_$index',
+      transactionId: transactionId,
+      accountId: accountId,
+      direction: direction,
+      amount: amount,
+      memo: _emptyToNull(memoText),
+    );
+  }
+
+  bool _looksLikeIsoDate(String value) {
+    return RegExp(r'^\d{4}-\d{2}-\d{2}$').hasMatch(value);
+  }
+
+  String? _emptyToNull(String value) {
+    final text = value.trim();
+    return text.isEmpty ? null : text;
+  }
+
+  List<DropdownMenuItem<String>> _buildTransactionTypeItems() {
+    return [
+      DropdownMenuItem<String>(
+        value: 'income',
+        child: Text(_termService.getTransactionLabel(TransactionTerm.income)),
+      ),
+      DropdownMenuItem<String>(
+        value: 'expense',
+        child: Text(_termService.getTransactionLabel(TransactionTerm.expense)),
+      ),
+      DropdownMenuItem<String>(
+        value: 'transfer',
+        child: Text(_termService.getTransactionLabel(TransactionTerm.transfer)),
+      ),
+      DropdownMenuItem<String>(
+        value: 'credit_expense',
+        child: Text(
+            _termService.getTransactionLabel(TransactionTerm.creditExpense)),
+      ),
+      DropdownMenuItem<String>(
+        value: 'liability_payment',
+        child: Text(
+            _termService.getTransactionLabel(TransactionTerm.liabilityPayment)),
+      ),
+      DropdownMenuItem<String>(
+        value: 'advance_payment',
+        child: Text(
+            _termService.getTransactionLabel(TransactionTerm.advancePayment)),
+      ),
+      DropdownMenuItem<String>(
+        value: 'reimbursement',
+        child: Text(
+            _termService.getTransactionLabel(TransactionTerm.reimbursement)),
+      ),
+    ];
+  }
+}
+
+final _suggestedTemplatesProvider =
+    FutureProvider<List<TransactionTemplate>>((ref) async {
+  return ref.watch(templateServiceProvider).listTemplates();
+});
+
+class _Section extends StatelessWidget {
+  const _Section({
+    required this.title,
+    required this.child,
+  });
+
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(title, style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 12),
+            child,
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EntryCard extends ConsumerWidget {
+  const _EntryCard({
+    required this.entryIndex,
+    required this.accounts,
+    required this.accountId,
+    required this.onAccountChanged,
+    required this.direction,
+    required this.onDirectionChanged,
+    required this.amountController,
+    required this.memoController,
+  });
+
+  final int entryIndex;
+  final List<ChoboAccountRecord> accounts;
+  final String? accountId;
+  final ValueChanged<String?> onAccountChanged;
+  final String direction;
+  final ValueChanged<String?> onDirectionChanged;
+  final TextEditingController amountController;
+  final TextEditingController memoController;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final termService = ref.watch(terminologyServiceProvider);
+    return Card(
+      elevation: 0,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              termService.getEntryLabelForIndex(entryIndex),
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+            const SizedBox(height: 12),
+            DropdownButtonFormField<String>(
+              value: accountId,
+              decoration: InputDecoration(
+                labelText: termService.getFieldLabel(FieldTerm.account),
+              ),
+              items: accounts.map(
+                (account) {
+                  final displayName =
+                      termService.getStandardAccountName(account.name);
+                  return DropdownMenuItem<String>(
+                    value: account.accountId,
+                    child: Text('$displayName (${account.accountId})'),
+                  );
+                },
+              ).toList(growable: false),
+              onChanged: onAccountChanged,
+              validator: (value) {
+                if (value == null || value.isEmpty) {
+                  return '口座を選択してください。';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<String>(
+              value: direction,
+              decoration: InputDecoration(
+                labelText: termService.getFieldLabel(FieldTerm.direction),
+              ),
+              items: [
+                DropdownMenuItem<String>(
+                  value: 'decrease',
+                  child: Text(
+                      termService.getDirectionLabel(DirectionTerm.decrease)),
+                ),
+                DropdownMenuItem<String>(
+                  value: 'increase',
+                  child: Text(
+                      termService.getDirectionLabel(DirectionTerm.increase)),
+                ),
+              ],
+              onChanged: onDirectionChanged,
+              validator: (value) {
+                if (value == null || value.isEmpty) {
+                  return '方向を選択してください。';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: amountController,
+              keyboardType: TextInputType.number,
+              decoration: InputDecoration(
+                labelText: termService.getFieldLabel(FieldTerm.amount),
+              ),
+              validator: (value) {
+                final amount = int.tryParse(value?.trim() ?? '');
+                if (amount == null || amount <= 0) {
+                  return '1以上の金額を入力してください。';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: memoController,
+              decoration: InputDecoration(
+                labelText: termService.getFieldLabel(FieldTerm.memo),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TemplateSelectorSheet extends StatelessWidget {
+  const _TemplateSelectorSheet({
+    required this.templates,
+    required this.onSelected,
+  });
+
+  final List<TransactionTemplate> templates;
+  final void Function(TransactionTemplate) onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text(
+            'テンプレートを選択',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+        ),
+        const Divider(height: 1),
+        if (templates.isEmpty)
+          const Padding(
+            padding: EdgeInsets.all(32),
+            child: Text('テンプレートがありません'),
+          )
+        else
+          Flexible(
+            child: ListView.builder(
+              shrinkWrap: true,
+              itemCount: templates.length,
+              itemBuilder: (context, index) {
+                final template = templates[index];
+                return ListTile(
+                  leading: const Icon(Icons.bookmark_outline),
+                  title: Text(template.name),
+                  subtitle: Text(_typeLabel(template.transactionType)),
+                  trailing: Text(
+                    '${template.usageCount}回使用',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                  onTap: () => onSelected(template),
+                );
+              },
+            ),
+          ),
+        const SizedBox(height: 16),
+      ],
+    );
+  }
+
+  String _typeLabel(String type) {
+    return switch (type) {
+      'income' => '収入',
+      'expense' => '支出',
+      'transfer' => '振替',
+      'credit_expense' => '請求',
+      'liability_payment' => '支払',
+      'advance_payment' => '立替',
+      'reimbursement' => '精算',
+      _ => type,
+    };
+  }
+}

--- a/lib/widgets/tag_widgets.dart
+++ b/lib/widgets/tag_widgets.dart
@@ -22,12 +22,12 @@ final transactionTagsProvider =
 class TagSelector extends ConsumerStatefulWidget {
   const TagSelector({
     super.key,
-    required this.transactionId,
+    this.transactionId,
     required this.selectedTagIds,
     required this.onTagsChanged,
   });
 
-  final String transactionId;
+  final String? transactionId;
   final List<String> selectedTagIds;
   final ValueChanged<List<String>> onTagsChanged;
 

--- a/test/data/local_db/chobo_schema_test.dart
+++ b/test/data/local_db/chobo_schema_test.dart
@@ -4,13 +4,13 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('ChoboSchema', () {
     test('declares the first schema version', () {
-      expect(ChoboSchema.schemaVersion, 5);
+      expect(ChoboSchema.schemaVersion, 10);
     });
 
     test('includes the core tables required by the backup payload', () {
       expect(
         ChoboSchema.createStatements,
-        hasLength(9),
+        hasLength(16),
       );
       final combinedStatements = ChoboSchema.createStatements.join('\n');
       expect(


### PR DESCRIPTION
## Summary
Implements parent issue #12 and child issues #44, #45, #46 for search and input assist features.

### Issue #44 - Search Filters
- `TransactionSearchRepository` with multi-axis filtering (date range, account, type, status, tags, counterparty, description)
- Pagination support for scaling

### Issue #45 - Reusable Templates
- `TemplateRepository` and `TemplateService`
- New `transaction_templates` table with usage tracking
- Template application in transaction creation

### Issue #46 - Suggestions & Autocomplete
- `AutocompleteRepository` and `SuggestionService`
- Smart ranking: recency (40%) + frequency (30%) + relevance (30%)
- `AutocompleteTextField` reusable widget

### Files Changed
- **Schema**: `chobo_schema.dart`, `chobo_migration.dart`, `chobo_records.dart`
- **Models**: `search_models.dart`
- **Repositories**: `transaction_search_repository.dart`, `template_repository.dart`, `autocomplete_repository.dart`
- **Services**: `transaction_search_service.dart`, `template_service.dart`, `suggestion_service.dart`
- **UI**: `search_screen.dart`, `transaction_create_screen.dart`, `autocomplete_text_field.dart`, `home_screen.dart`
- **Config**: `chobo_providers.dart`, `router.dart`

### Schema Version
- Bumped from 9 to 10

### Tests
- Updated `chobo_schema_test.dart` for schema v10